### PR TITLE
Add generic `Gpio` type

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -84,7 +84,7 @@ impl<MODE> OutputPin for Gpio<Output<MODE>> {
             }
             32..=33 => {
                 unsafe {
-                    gpio.out_w1tc.write(|w| w.bits(1 << (self.pin - 32)))
+                    gpio.out1_w1tc.write(|w| w.bits(1 << (self.pin - 32)))
                 };
             }
             _ => unreachable!()


### PR DESCRIPTION
This type is useful to implement other peripherals that need access to
GPIO pins.

I've added a small TODO to implement `into_*_output` function for this
type, I'm not sure how to proceed since the esp32 with
`funcX_out_sel_cfg` is unergonomic and the code would need to match over
each pin to use the correct register. This can be resolved by making
these registers an array.