### PR TITLE
Add analog module

### DIFF
--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -26,9 +26,13 @@ fn main() -> ! {
     // we will do it manually on startup
     disable_timg_wdts(&mut timg0, &mut timg1);
 
-    let clkcntrl =
-        esp32_hal::clock_control::ClockControl::new(dp.RTCCNTL, dp.APB_CTRL, dport_clock_control)
-            .unwrap();
+    let clkcntrl = esp32_hal::clock_control::ClockControl::new(
+        dp.RTCCNTL,
+        dp.APB_CTRL,
+        dport_clock_control,
+        esp32_hal::clock_control::XTAL_FREQUENCY_AUTO,
+    )
+    .unwrap();
 
     let (clkcntrl_config, mut watchdog) = clkcntrl.freeze().unwrap();
     watchdog.disable();
@@ -42,6 +46,7 @@ fn main() -> ! {
         &mut dport,
     )
     .unwrap();
+
     let (mut tx, _rx) = serial.split();
 
     /* Set ADC pins to analog mode */
@@ -90,5 +95,5 @@ fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
 /// Basic panic handler - just loops
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
-    loop { }
+    loop {}
 }

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -1,0 +1,94 @@
+#![no_std]
+#![no_main]
+
+use core::fmt::Write;
+use core::panic::PanicInfo;
+
+use esp32_hal::prelude::*;
+
+use esp32_hal::analog::adc::ADC;
+use esp32_hal::analog::config::{Adc1Config, Adc2Config, Attenuation};
+use esp32_hal::clock_control::sleep;
+use esp32_hal::dport::Split;
+use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
+
+#[no_mangle]
+fn main() -> ! {
+    let dp = unsafe { esp32::Peripherals::steal() };
+
+    let mut timg0 = dp.TIMG0;
+    let mut timg1 = dp.TIMG1;
+
+    let (mut dport, dport_clock_control) = dp.DPORT.split();
+
+    // (https://github.com/espressif/openocd-esp32/blob/97ba3a6bb9eaa898d91df923bbedddfeaaaf28c9/src/target/esp32.c#L431)
+    // openocd disables the watchdog timer on halt
+    // we will do it manually on startup
+    disable_timg_wdts(&mut timg0, &mut timg1);
+
+    let clkcntrl =
+        esp32_hal::clock_control::ClockControl::new(dp.RTCCNTL, dp.APB_CTRL, dport_clock_control)
+            .unwrap();
+
+    let (clkcntrl_config, mut watchdog) = clkcntrl.freeze().unwrap();
+    watchdog.disable();
+
+    /* Setup serial connection */
+    let serial = Serial::uart0(
+        dp.UART0,
+        (NoTx, NoRx),
+        Config::default(),
+        clkcntrl_config,
+        &mut dport,
+    )
+    .unwrap();
+    let (mut tx, _rx) = serial.split();
+
+    /* Set ADC pins to analog mode */
+    let gpios = dp.GPIO.split();
+    let mut pin36 = gpios.gpio36.into_analog();
+    let mut pin25 = gpios.gpio25.into_analog();
+
+    /* Prepare ADC configs and enable pins, which will be used */
+    let mut adc1_config = Adc1Config::new();
+    adc1_config.enable_pin(&pin36, Attenuation::Attenuation11dB);
+
+    let mut adc2_config = Adc2Config::new();
+    adc2_config.enable_pin(&pin25, Attenuation::Attenuation11dB);
+
+    /* Create ADC instances */
+    let analog = dp.SENS.split();
+    let mut adc1 = ADC::adc1(analog.adc1, adc1_config).unwrap();
+    let mut adc2 = ADC::adc2(analog.adc2, adc2_config).unwrap();
+
+    loop {
+        /* Read ADC values every second and print them out */
+        let pin36_value: u16 = nb::block!(adc1.read(&mut pin36)).unwrap();
+        writeln!(tx, "ADC1 pin 36 raw value: {:?}", pin36_value).unwrap();
+
+        let pin25_value: u16 = nb::block!(adc2.read(&mut pin25)).unwrap();
+        writeln!(tx, "ADC2 pin 25 raw value: {:?}", pin25_value).unwrap();
+
+        sleep(1.s());
+    }
+}
+
+const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
+
+fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
+    timg0
+        .wdtwprotect
+        .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });
+    timg1
+        .wdtwprotect
+        .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });
+
+    timg0.wdtconfig0.write(|w| unsafe { w.bits(0x0) });
+    timg1.wdtconfig0.write(|w| unsafe { w.bits(0x0) });
+}
+
+/// Basic panic handler - just loops
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop { }
+}

--- a/examples/dac.rs
+++ b/examples/dac.rs
@@ -23,9 +23,13 @@ fn main() -> ! {
     // we will do it manually on startup
     disable_timg_wdts(&mut timg0, &mut timg1);
 
-    let clkcntrl =
-        esp32_hal::clock_control::ClockControl::new(dp.RTCCNTL, dp.APB_CTRL, dport_clock_control)
-            .unwrap();
+    let clkcntrl = esp32_hal::clock_control::ClockControl::new(
+        dp.RTCCNTL,
+        dp.APB_CTRL,
+        dport_clock_control,
+        esp32_hal::clock_control::XTAL_FREQUENCY_AUTO,
+    )
+    .unwrap();
 
     let (_clkcntrl_config, mut watchdog) = clkcntrl.freeze().unwrap();
     watchdog.disable();
@@ -71,5 +75,5 @@ fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
 /// Basic panic handler - just loops
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
-    loop { }
+    loop {}
 }

--- a/examples/dac.rs
+++ b/examples/dac.rs
@@ -1,0 +1,75 @@
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+
+use esp32_hal::prelude::*;
+
+use esp32_hal::analog::dac::DAC;
+use esp32_hal::clock_control::sleep;
+use esp32_hal::dport::Split;
+
+#[no_mangle]
+fn main() -> ! {
+    let dp = unsafe { esp32::Peripherals::steal() };
+
+    let mut timg0 = dp.TIMG0;
+    let mut timg1 = dp.TIMG1;
+
+    let (_dport, dport_clock_control) = dp.DPORT.split();
+
+    // (https://github.com/espressif/openocd-esp32/blob/97ba3a6bb9eaa898d91df923bbedddfeaaaf28c9/src/target/esp32.c#L431)
+    // openocd disables the watchdog timer on halt
+    // we will do it manually on startup
+    disable_timg_wdts(&mut timg0, &mut timg1);
+
+    let clkcntrl =
+        esp32_hal::clock_control::ClockControl::new(dp.RTCCNTL, dp.APB_CTRL, dport_clock_control)
+            .unwrap();
+
+    let (_clkcntrl_config, mut watchdog) = clkcntrl.freeze().unwrap();
+    watchdog.disable();
+
+    /* Set DAC pins to analog mode. The pins are specified by hardware and cannot be changed */
+    let gpios = dp.GPIO.split();
+    let pin25 = gpios.gpio25.into_analog();
+    let pin26 = gpios.gpio26.into_analog();
+
+    /* Create DAC instances */
+    let analog = dp.SENS.split();
+    let mut dac1 = DAC::dac1(analog.dac1, pin25).unwrap();
+    let mut dac2 = DAC::dac2(analog.dac2, pin26).unwrap();
+
+    let mut voltage_dac1: u8 = 0;
+    let mut voltage_dac2: u8 = 255;
+    loop {
+        /* Change voltage on the pins using write function */
+        voltage_dac1 = voltage_dac1.wrapping_add(1);
+        dac1.write(voltage_dac1);
+
+        voltage_dac2 = voltage_dac2.wrapping_sub(1);
+        dac2.write(voltage_dac2);
+
+        sleep(250.ms());
+    }
+}
+
+const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
+
+fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
+    timg0
+        .wdtwprotect
+        .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });
+    timg1
+        .wdtwprotect
+        .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });
+
+    timg0.wdtconfig0.write(|w| unsafe { w.bits(0x0) });
+    timg1.wdtconfig0.write(|w| unsafe { w.bits(0x0) });
+}
+
+/// Basic panic handler - just loops
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop { }
+}

--- a/examples/hall.rs
+++ b/examples/hall.rs
@@ -1,0 +1,89 @@
+#![no_std]
+#![no_main]
+
+use core::fmt::Write;
+use core::panic::PanicInfo;
+
+use esp32_hal::prelude::*;
+
+use esp32_hal::analog::adc::ADC;
+use esp32_hal::analog::config::{Adc1Config, Attenuation};
+use esp32_hal::clock_control::sleep;
+use esp32_hal::dport::Split;
+use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
+
+#[no_mangle]
+fn main() -> ! {
+    let dp = unsafe { esp32::Peripherals::steal() };
+
+    let mut timg0 = dp.TIMG0;
+    let mut timg1 = dp.TIMG1;
+
+    let (mut dport, dport_clock_control) = dp.DPORT.split();
+
+    // (https://github.com/espressif/openocd-esp32/blob/97ba3a6bb9eaa898d91df923bbedddfeaaaf28c9/src/target/esp32.c#L431)
+    // openocd disables the watchdog timer on halt
+    // we will do it manually on startup
+    disable_timg_wdts(&mut timg0, &mut timg1);
+
+    let clkcntrl =
+        esp32_hal::clock_control::ClockControl::new(dp.RTCCNTL, dp.APB_CTRL, dport_clock_control)
+            .unwrap();
+
+    let (clkcntrl_config, mut watchdog) = clkcntrl.freeze().unwrap();
+    watchdog.disable();
+
+    /* Setup serial connection */
+    let serial = Serial::uart0(
+        dp.UART0,
+        (NoTx, NoRx),
+        Config::default(),
+        clkcntrl_config,
+        &mut dport,
+    )
+    .unwrap();
+    let (mut tx, _rx) = serial.split();
+
+    /* Set ADC pins to analog mode */
+    let gpios = dp.GPIO.split();
+    let mut pin36 = gpios.gpio36.into_analog();
+    let mut pin39 = gpios.gpio39.into_analog();
+
+    /* In the configuration enable hall sensor and its pins (36 and 39) */
+    let mut adc_config = Adc1Config::new();
+    adc_config.enable_hall_sensor();
+    adc_config.enable_pin(&pin36, Attenuation::Attenuation0dB);
+    adc_config.enable_pin(&pin39, Attenuation::Attenuation0dB);
+
+    /* Hall sensor is only available on the ADC1 */
+    let analog = dp.SENS.split();
+    let mut adc1 = ADC::adc1(analog.adc1, adc_config).unwrap();
+
+    loop {
+        /* Read the sensor and print out the raw value once per second */
+        let hall_sensor_value: i32 = adc1.read_hall_sensor(&mut pin36, &mut pin39);
+        writeln!(tx, "Hall sensor raw value: {:?}", hall_sensor_value).unwrap();
+
+        sleep(1.s());
+    }
+}
+
+const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
+
+fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
+    timg0
+        .wdtwprotect
+        .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });
+    timg1
+        .wdtwprotect
+        .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });
+
+    timg0.wdtconfig0.write(|w| unsafe { w.bits(0x0) });
+    timg1.wdtconfig0.write(|w| unsafe { w.bits(0x0) });
+}
+
+/// Basic panic handler - just loops
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop { }
+}

--- a/examples/hall.rs
+++ b/examples/hall.rs
@@ -26,9 +26,13 @@ fn main() -> ! {
     // we will do it manually on startup
     disable_timg_wdts(&mut timg0, &mut timg1);
 
-    let clkcntrl =
-        esp32_hal::clock_control::ClockControl::new(dp.RTCCNTL, dp.APB_CTRL, dport_clock_control)
-            .unwrap();
+    let clkcntrl = esp32_hal::clock_control::ClockControl::new(
+        dp.RTCCNTL,
+        dp.APB_CTRL,
+        dport_clock_control,
+        esp32_hal::clock_control::XTAL_FREQUENCY_AUTO,
+    )
+    .unwrap();
 
     let (clkcntrl_config, mut watchdog) = clkcntrl.freeze().unwrap();
     watchdog.disable();
@@ -85,5 +89,5 @@ fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
 /// Basic panic handler - just loops
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
-    loop { }
+    loop {}
 }

--- a/src/analog/adc.rs
+++ b/src/analog/adc.rs
@@ -1,0 +1,267 @@
+//! Analog to digital (ADC) conversion support.
+//!
+//! This module provides functions for reading analog values from two
+//! analog to digital converters available on the ESP32: `ADC1` and `ADC2`.
+//!
+//! The following pins can be configured for analog readout:
+//! 
+//! | Channel | ADC1                 | ADC2          |
+//! |---------|----------------------|---------------|
+//! | 0       | GPIO36 (SENSOR_VP)   | GPIO4         |
+//! | 1       | GPIO37 (SENSOR_CAPP) | GPIO0         |
+//! | 2       | GPIO38 (SENSOR_CAPN) | GPIO2         |
+//! | 3       | GPIO39 (SENSOR_VN)   | GPIO15 (MTDO) |
+//! | 4       | GPIO33 (32K_XP)      | GPIO13 (MTCK) |
+//! | 5       | GPIO32 (32K_XN)      | GPIO12 (MTDI) |
+//! | 6       | GPIO34 (VDET_1)      | GPIO14 (MTMS) |
+//! | 7       | GPIO35 (VDET_2)      | GPIO27        |
+//! | 8       |                      | GPIO25        |
+//! | 9       |                      | GPIO26        |
+//!
+
+use core::marker::PhantomData;
+use embedded_hal::adc::{Channel, OneShot};
+use esp32::{RTCIO, SENS};
+
+use crate::analog::config;
+use crate::analog::{ADC1, ADC2};
+use crate::gpio::*;
+
+
+pub struct ADC<ADC> {
+    adc: PhantomData<ADC>,
+    attenuations: [Option<config::Attenuation>; 10],
+    active_channel: Option<u8>,
+}
+
+macro_rules! impl_adc_setup {
+    ($config:expr, $bit_width:ident, $read_reg:ident, $sample_bit:ident, $atten_reg: ident,
+        $atten_field:ident, $dig_force:ident, $meas_start_reg:ident,
+        $start_force_field:ident, $en_pad_force:ident) => {
+        let sensors = unsafe { &*SENS::ptr() };
+
+        /* Set reading and sampling resolution */
+        let resolution: u8 = $config.resolution as u8;
+
+        sensors
+            .sar_start_force
+            .modify(|_, w| unsafe { w.$bit_width().bits(resolution) });
+        sensors
+            .$read_reg
+            .modify(|_, w| unsafe { w.$sample_bit().bits(resolution) });
+
+        /* Set attenuation for pins */
+        let attenuations = $config.attenuations;
+
+        for channel in 0..attenuations.len() {
+            if let Some(attenuation) = attenuations[channel] {
+                sensors.$atten_reg.modify(|r, w| {
+                    let new_value = (r.bits() & !(0b11 << (channel * 2)))
+                        | (((attenuation as u8 & 0b11) as u32) << (channel * 2));
+
+                    unsafe { w.$atten_field().bits(new_value) }
+                });
+            }
+        }
+
+        /* Set controller to RTC */
+        sensors.$read_reg.modify(|_, w| w.$dig_force().clear_bit());
+        sensors
+            .$meas_start_reg
+            .modify(|_, w| w.$start_force_field().set_bit());
+        sensors
+            .$meas_start_reg
+            .modify(|_, w| w.$en_pad_force().set_bit());
+        sensors
+            .sar_touch_ctrl1
+            .modify(|_, w| w.xpd_hall_force().set_bit());
+        sensors
+            .sar_touch_ctrl1
+            .modify(|_, w| w.hall_phase_force().set_bit());
+
+        /* Set power to SW power on */
+        sensors
+            .sar_meas_wait2
+            .modify(|_, w| unsafe { w.force_xpd_sar().bits(0b11) });
+
+        /* disable AMP */
+        sensors
+            .sar_meas_wait2
+            .modify(|_, w| unsafe { w.force_xpd_amp().bits(0b10) });
+        sensors
+            .sar_meas_ctrl
+            .modify(|_, w| unsafe { w.amp_rst_fb_fsm().bits(0) });
+        sensors
+            .sar_meas_ctrl
+            .modify(|_, w| unsafe { w.amp_short_ref_fsm().bits(0) });
+        sensors
+            .sar_meas_ctrl
+            .modify(|_, w| unsafe { w.amp_short_ref_gnd_fsm().bits(0) });
+        sensors
+            .sar_meas_wait1
+            .modify(|_, w| unsafe { w.sar_amp_wait1().bits(1) });
+        sensors
+            .sar_meas_wait1
+            .modify(|_, w| unsafe { w.sar_amp_wait2().bits(1) });
+        sensors
+            .sar_meas_wait2
+            .modify(|_, w| unsafe { w.sar_amp_wait3().bits(1) });
+    };
+}
+
+impl ADC<ADC1> {
+    pub fn adc1(_adc_instance: ADC1, config: config::Adc1Config) -> Result<Self, ()> {
+        impl_adc_setup!(
+            config,
+            sar1_bit_width,
+            sar_read_ctrl,
+            sar1_sample_bit,
+            sar_atten1,
+            sar1_atten,
+            sar1_dig_force,
+            sar_meas_start1,
+            meas1_start_force,
+            sar1_en_pad_force
+        );
+
+        /* Connect or disconnect hall sensor */
+        let rtcio = unsafe { &*RTCIO::ptr() };
+
+        if config.hall_sensor {
+            rtcio
+                .rtc_io_hall_sens
+                .modify(|_, w| w.rtc_io_xpd_hall().set_bit());
+        } else {
+            rtcio
+                .rtc_io_hall_sens
+                .modify(|_, w| w.rtc_io_xpd_hall().clear_bit());
+        }
+
+        let adc = ADC {
+            adc: PhantomData,
+            attenuations: config.attenuations,
+            active_channel: None,
+        };
+
+        Ok(adc)
+    }
+}
+
+impl ADC<ADC2> {
+    pub fn adc2(_adc_instance: ADC2, config: config::Adc2Config) -> Result<Self, ()> {
+        impl_adc_setup!(
+            config,
+            sar2_bit_width,
+            sar_read_ctrl2,
+            sar2_sample_bit,
+            sar_atten2,
+            sar2_atten,
+            sar2_dig_force,
+            sar_meas_start2,
+            meas2_start_force,
+            sar2_en_pad_force
+        );
+
+        let adc = ADC {
+            adc: PhantomData,
+            attenuations: config.attenuations,
+            active_channel: None,
+        };
+
+        Ok(adc)
+    }
+}
+
+macro_rules! impl_adc_interface {
+    ($adc:ident ($start_reg:ident, $en_pad:ident, $start:ident, $done:ident, $data:ident): [
+        $( ($pin:ident, $channel:expr) ,)+
+    ]) => {
+
+        impl<WORD, PIN> OneShot<$adc, WORD, PIN> for ADC<$adc>
+        where
+        WORD: From<u16>,
+        PIN: Channel<$adc, ID=u8>,
+        {
+            type Error = ();
+
+            fn read(&mut self, _pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
+                let sensors = unsafe { &*SENS::ptr() };
+
+                if self.attenuations[PIN::channel() as usize] == None {
+                    panic!("Channel {} is not configured reading!", PIN::channel());
+                }
+
+                if let Some(active_channel) = self.active_channel {
+                    // There is conversion in progress:
+                    // - if it's for a different channel try again later
+                    // - if it's for the given channel, go ahaid and check progress
+                    if active_channel != PIN::channel() {
+                        return Err(nb::Error::WouldBlock);
+                    }
+                }
+                else {
+                    // If no conversions are in progress, start a new one for given channel
+                    self.active_channel = Some(PIN::channel());
+
+                    sensors.$start_reg.modify(|_, w| {
+                        unsafe { w.$en_pad().bits(1 << PIN::channel() as u8) }
+                    });
+
+                    sensors.$start_reg.modify(|_,w| w.$start().clear_bit());
+                    sensors.$start_reg.modify(|_,w| w.$start().set_bit());
+                }
+
+                // Wait for ADC to finish conversion
+                let conversion_finished = sensors.$start_reg.read().$done().bit_is_set();
+                if !conversion_finished {
+                    return Err(nb::Error::WouldBlock);
+                }
+
+                // Get converted value
+                let converted_value = sensors.$start_reg.read().$data().bits() as u16;
+
+                // Mark that no conversions are currently in progress
+                self.active_channel = None;
+
+                Ok(converted_value.into())
+            }
+        }
+
+
+        $(
+            impl Channel<$adc> for $pin<Analog> {
+                type ID = u8;
+
+                fn channel() -> u8 { $channel }
+            }
+        )+
+    }
+}
+
+impl_adc_interface! {
+    ADC1 (sar_meas_start1, sar1_en_pad, meas1_start_sar, meas1_done_sar, meas1_data_sar): [
+        (Gpio36, 0), // Alt. name: SENSOR_VP
+        (Gpio37, 1), // Alt. name: SENSOR_CAPP
+        (Gpio38, 2), // Alt. name: SENSOR_CAPN
+        (Gpio39, 3), // Alt. name: SENSOR_VN
+        (Gpio33, 4), // Alt. name: 32K_XP
+        (Gpio32, 5), // Alt. name: 32K_XN
+        (Gpio34, 6), // Alt. name: VDET_1
+        (Gpio35, 7), // Alt. name: VDET_2
+    ]
+}
+
+impl_adc_interface! {
+    ADC2 (sar_meas_start2, sar2_en_pad, meas2_start_sar, meas2_done_sar, meas2_data_sar): [
+        (Gpio4, 0),
+        (Gpio0, 1),
+        (Gpio2, 2),
+        (Gpio15, 3), // Alt. name: MTDO
+        (Gpio13, 4), // Alt. name: MTCK
+        (Gpio12, 5), // Alt. name: MTDI
+        (Gpio14, 6), // Alt. name: MTMS
+        (Gpio27, 7),
+        (Gpio25, 8),
+        (Gpio26, 9),
+    ]
+}

--- a/src/analog/adc.rs
+++ b/src/analog/adc.rs
@@ -4,7 +4,7 @@
 //! analog to digital converters available on the ESP32: `ADC1` and `ADC2`.
 //!
 //! The following pins can be configured for analog readout:
-//! 
+//!
 //! | Channel | ADC1                 | ADC2          |
 //! |---------|----------------------|---------------|
 //! | 0       | GPIO36 (SENSOR_VP)   | GPIO4         |
@@ -26,7 +26,6 @@ use esp32::{RTCIO, SENS};
 use crate::analog::config;
 use crate::analog::{ADC1, ADC2};
 use crate::gpio::*;
-
 
 pub struct ADC<ADC> {
     adc: PhantomData<ADC>,

--- a/src/analog/config.rs
+++ b/src/analog/config.rs
@@ -1,0 +1,72 @@
+//! Configuration of analog modules.
+
+use crate::analog::{ADC1, ADC2};
+use embedded_hal::adc::Channel;
+
+/// The sampling/readout resolution of the ADC
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum Resolution {
+    Resolution9Bit = 0b00,
+    Resolution10Bit = 0b01,
+    Resolution11Bit = 0b10,
+    Resolution12Bit = 0b11,
+}
+
+/// The attenuation of the ADC pin
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum Attenuation {
+    Attenuation0dB = 0b00,
+    Attenuation2p5dB = 0b01,
+    Attenuation6dB = 0b10,
+    Attenuation11dB = 0b11,
+}
+
+pub struct Adc1Config {
+    pub resolution: Resolution,
+    pub hall_sensor: bool,
+    pub attenuations: [Option<Attenuation>; 10],
+}
+
+impl Adc1Config {
+    pub fn new() -> Adc1Config {
+        Adc1Config {
+            resolution: Resolution::Resolution12Bit,
+            hall_sensor: false,
+            attenuations: [None; 10],
+        }
+    }
+
+    pub fn enable_pin<PIN: Channel<ADC1, ID = u8>>(
+        &mut self,
+        _pin: &PIN,
+        attenuation: Attenuation,
+    ) {
+        self.attenuations[PIN::channel() as usize] = Some(attenuation);
+    }
+
+    pub fn enable_hall_sensor(&mut self) {
+        self.hall_sensor = true;
+    }
+}
+
+pub struct Adc2Config {
+    pub resolution: Resolution,
+    pub attenuations: [Option<Attenuation>; 10],
+}
+
+impl Adc2Config {
+    pub fn new() -> Adc2Config {
+        Adc2Config {
+            resolution: Resolution::Resolution12Bit,
+            attenuations: [None; 10],
+        }
+    }
+
+    pub fn enable_pin<PIN: Channel<ADC2, ID = u8>>(
+        &mut self,
+        _pin: &PIN,
+        attenuation: Attenuation,
+    ) {
+        self.attenuations[PIN::channel() as usize] = Some(attenuation);
+    }
+}

--- a/src/analog/dac.rs
+++ b/src/analog/dac.rs
@@ -1,10 +1,10 @@
 //! Digital to analog (DAC) conversion.
-//! 
+//!
 //! This module provides functions for controling two digital to
 //! analog converters, available on ESP32: `DAC1` and `DAC2`.
-//! 
+//!
 //! The DAC1 is avilable on the GPIO pin 25, and DAC2 on pin 26.
-//! 
+//!
 
 use core::marker::PhantomData;
 use esp32::{RTCIO, SENS};

--- a/src/analog/dac.rs
+++ b/src/analog/dac.rs
@@ -1,0 +1,79 @@
+//! Digital to analog (DAC) conversion.
+//! 
+//! This module provides functions for controling two digital to
+//! analog converters, available on ESP32: `DAC1` and `DAC2`.
+//! 
+//! The DAC1 is avilable on the GPIO pin 25, and DAC2 on pin 26.
+//! 
+
+use core::marker::PhantomData;
+use esp32::{RTCIO, SENS};
+
+use crate::analog::{DAC1, DAC2};
+use crate::gpio::{Analog, Gpio25, Gpio26};
+
+pub struct DAC<DAC> {
+    _dac: PhantomData<DAC>,
+}
+
+impl DAC<DAC1> {
+    pub fn dac1(_dac: DAC1, _pin: Gpio25<Analog>) -> Result<Self, ()> {
+        let dac = DAC::<DAC1> { _dac: PhantomData }.set_power();
+
+        Ok(dac)
+    }
+
+    fn set_power(self) -> Self {
+        let rtcio = unsafe { &*RTCIO::ptr() };
+
+        rtcio.rtc_io_pad_dac1.modify(|_, w| {
+            w.rtc_io_pdac1_dac_xpd_force().set_bit();
+            w.rtc_io_pdac1_xpd_dac().set_bit()
+        });
+
+        self
+    }
+
+    pub fn write(&mut self, value: u8) {
+        let rtcio = unsafe { &*RTCIO::ptr() };
+        let sensors = unsafe { &*SENS::ptr() };
+
+        sensors
+            .sar_dac_ctrl2
+            .modify(|_, w| w.dac_cw_en1().clear_bit());
+        rtcio
+            .rtc_io_pad_dac1
+            .modify(|_, w| unsafe { w.rtc_io_pdac1_dac().bits(value) });
+    }
+}
+
+impl DAC<DAC2> {
+    pub fn dac2(_dac: DAC2, _pin: Gpio26<Analog>) -> Result<Self, ()> {
+        let dac = DAC::<DAC2> { _dac: PhantomData }.set_power();
+
+        Ok(dac)
+    }
+
+    fn set_power(self) -> Self {
+        let rtcio = unsafe { &*RTCIO::ptr() };
+
+        rtcio.rtc_io_pad_dac2.modify(|_, w| {
+            w.rtc_io_pdac2_dac_xpd_force().set_bit();
+            w.rtc_io_pdac2_xpd_dac().set_bit()
+        });
+
+        self
+    }
+
+    pub fn write(&mut self, value: u8) {
+        let rtcio = unsafe { &*RTCIO::ptr() };
+        let sensors = unsafe { &*SENS::ptr() };
+
+        sensors
+            .sar_dac_ctrl2
+            .modify(|_, w| w.dac_cw_en2().clear_bit());
+        rtcio
+            .rtc_io_pad_dac2
+            .modify(|_, w| unsafe { w.rtc_io_pdac2_dac().bits(value) });
+    }
+}

--- a/src/analog/hall.rs
+++ b/src/analog/hall.rs
@@ -1,11 +1,11 @@
 //! Built-in hall sensor readout.
-//! 
+//!
 //! This module provides a function for reading current value of the built-in
 //! hall sensor.
-//! 
+//!
 
-use esp32::RTCIO;
 use embedded_hal::adc::OneShot;
+use esp32::RTCIO;
 
 use crate::analog::adc::ADC;
 use crate::analog::ADC1;

--- a/src/analog/hall.rs
+++ b/src/analog/hall.rs
@@ -1,0 +1,36 @@
+//! Built-in hall sensor readout.
+//! 
+//! This module provides a function for reading current value of the built-in
+//! hall sensor.
+//! 
+
+use esp32::RTCIO;
+use embedded_hal::adc::OneShot;
+
+use crate::analog::adc::ADC;
+use crate::analog::ADC1;
+use crate::gpio::{Analog, Gpio36, Gpio39};
+
+impl ADC<ADC1> {
+    pub fn read_hall_sensor(
+        &mut self,
+        vp_pin: &mut Gpio36<Analog>,
+        vn_pin: &mut Gpio39<Analog>,
+    ) -> i32 {
+        let rtcio = unsafe { &*RTCIO::ptr() };
+
+        rtcio
+            .rtc_io_hall_sens
+            .modify(|_, w| w.rtc_io_hall_phase().clear_bit());
+        let vp1: u16 = nb::block!(self.read(vp_pin)).unwrap();
+        let vn1: u16 = nb::block!(self.read(vn_pin)).unwrap();
+
+        rtcio
+            .rtc_io_hall_sens
+            .modify(|_, w| w.rtc_io_hall_phase().set_bit());
+        let vp2: u16 = nb::block!(self.read(vp_pin)).unwrap();
+        let vn2: u16 = nb::block!(self.read(vn_pin)).unwrap();
+
+        (vp2 as i32 - vp1 as i32) - (vn2 as i32 - vn1 as i32)
+    }
+}

--- a/src/analog/mod.rs
+++ b/src/analog/mod.rs
@@ -1,8 +1,8 @@
 //! Analog peripherals control.
-//! 
+//!
 //! Provides functionality for using analog peripherals, such as ADCs, DACs
 //! and other sesnsors.
-//! 
+//!
 
 pub mod adc;
 pub mod config;

--- a/src/analog/mod.rs
+++ b/src/analog/mod.rs
@@ -1,0 +1,58 @@
+//! Analog peripherals control.
+//! 
+//! Provides functionality for using analog peripherals, such as ADCs, DACs
+//! and other sesnsors.
+//! 
+
+pub mod adc;
+pub mod config;
+pub mod dac;
+pub mod hall;
+
+use core::marker::PhantomData;
+use esp32::SENS;
+
+pub struct ADC1 {
+    _private: PhantomData<()>,
+}
+pub struct ADC2 {
+    _private: PhantomData<()>,
+}
+
+pub struct DAC1 {
+    _private: PhantomData<()>,
+}
+
+pub struct DAC2 {
+    _private: PhantomData<()>,
+}
+
+pub struct AvailableAnalog {
+    pub adc1: ADC1,
+    pub adc2: ADC2,
+    pub dac1: DAC1,
+    pub dac2: DAC2,
+}
+
+pub trait SensExt {
+    fn split(self) -> AvailableAnalog;
+}
+
+impl SensExt for SENS {
+    fn split(self) -> AvailableAnalog {
+        AvailableAnalog {
+            adc1: ADC1 {
+                _private: PhantomData,
+            },
+            adc2: ADC2 {
+                _private: PhantomData,
+            },
+            dac1: DAC1 {
+                _private: PhantomData,
+            },
+            dac2: DAC2 {
+                _private: PhantomData,
+            },
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 pub use embedded_hal as hal;
 pub use esp32;
 
+pub mod analog;
 pub mod clock_control;
 pub mod dport;
 pub mod efuse;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,5 +4,6 @@ pub use embedded_hal::digital::v2::StatefulOutputPin as _esp32_hal_digital_State
 pub use embedded_hal::digital::v2::ToggleableOutputPin as _esp32_hal_digital_ToggleableOutputPin;
 pub use embedded_hal::prelude::*;
 
+pub use crate::analog::SensExt as _esp32_hal_analog_SensExt;
 pub use crate::gpio::GpioExt as _esp32_hal_gpio_GpioExt;
 pub use crate::units::*;


### PR DESCRIPTION
### Analog module

This pull request brings API for using ADCs, DACs and hall sensor.

The examples build on the not-yet-merged serial API, so I'll keep this WIP, until that pull request is closed.

If you have any suggestions on how to improve the code, please let me know.

### Tested

I tested the following:
- ADC1:  pin 36, pin 39, pin 34, pin 35, pin 33, pin 32
- ADC2: pin 0, pin 2, pin 4, pin 12, pin 13, pin 14, pin 15, pin 25, pin 26, pin 27
- DAC1: pin 25
- DAC2: pin 26
- Hall sensor

I haven't tested:
- ADC1: pins 37 and 38, as I don't have them exposed on my board.

### Not included

Some functionality related to analog subsystem of the chip is not included in this PR: cosine-wave generator, touch sensors, vref/two-point calibration