### PR TITLE
More flexible linker support & running from flash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+procmacros/target
 **/*.rs.bk
 Cargo.lock
 .vscode/.cortex-debug*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,12 +44,6 @@
             "interface": "jtag",
             "svdFile": "../esp32/svd/esp32.svd",
             "toolchainPrefix": "xtensa-esp32-elf",
-            "debuggerArgs": [
-                "-iex",
-                "set verbose on",
-                "-iex",
-                "set trace-commands on",
-            ],
             "openOCDPreConfigLaunchCommands": [
                 "set ESP_RTOS none"
             ],
@@ -60,7 +54,7 @@
                 "mon program_esp32 target/current.bin 0x10000 verify reset hex",
                 "flushregs",
             ],
-            "postStartSessionCommands":[
+            "postStartSessionCommands": [
                 "thb main",
                 "continue"
             ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,41 +5,71 @@
     "version": "0.2.0",
     "configurations": [
         {
+            // more info at: https://github.com/Marus/cortex-debug/blob/master/package.json
+            "name": "Attach",
             "type": "cortex-debug",
+            "request": "attach", // attach instead of launch, because otherwise flash write is attempted, but fails
             "cwd": "${workspaceRoot}",
-            "executable": "target/xtensa-esp32-none-elf/debug/examples/${input:example}",
-            "name": "debug-with-svd",
-            "request": "launch",
+            "executable": "target/current.elf",
             "servertype": "openocd",
             "interface": "jtag",
             "svdFile": "../esp32/svd/esp32.svd",
-            // complains about not allowed,
-            // but it does work.. https://github.com/Marus/cortex-debug/issues/111#issuecomment-504778053
-            "serverpath": "${env:HOME}/programs/openocd-esp32/bin/openocd",
-            // for this to work you will have to run `ln -s xtensa-esp32-elf-gdb arm-none-eabi-gdb`
-            "toolchainPath": "${env:HOME}/programs/xtensa-esp32-elf/bin",
+            "toolchainPrefix": "xtensa-esp32-elf",
+            "openOCDPreConfigLaunchCommands": [
+                "set ESP_RTOS none"
+            ],
             "configFiles": [
                 "board/esp32-wrover-kit-3.3v.cfg"
             ],
+            "overrideAttachCommands": [
+                "set remote hardware-watchpoint-limit 2",
+                "mon halt",
+                "flushregs"
+            ],
+            "overrideRestartCommands": [
+                "mon reset halt",
+                "flushregs",
+                "c",
+            ]
         },
-    ],
-    "inputs": [
-        // requires Tasks Shell Input extension
         {
-            "id": "example",
-            "type": "command",
-            "command": "shellCommand.execute",
-            "args": {
-                "command": "egrep '\\[\\[example\\]\\]|name[ \t]+=' Cargo.toml | egrep '\\[\\[example\\]\\]' -A1 | egrep 'name[ \t]*=' | sed -E 's/name[ \t]*=[ \t]*//; s/\"//g'",
-                "cwd": "${workspaceFolder}/../esp32-hal"
-            }
+            // more info at: https://github.com/Marus/cortex-debug/blob/master/package.json
+            "name": "Flash & Launch",
+            "type": "cortex-debug",
+            "preLaunchTask": "Build Example",
+            "request": "launch", // attach instead of launch, because otherwise flash write is attempted, but fails
+            "cwd": "${workspaceRoot}",
+            "executable": "target/current.elf",
+            "servertype": "openocd",
+            "interface": "jtag",
+            "svdFile": "../esp32/svd/esp32.svd",
+            "toolchainPrefix": "xtensa-esp32-elf",
+            "debuggerArgs": [
+                "-iex",
+                "set verbose on",
+                "-iex",
+                "set trace-commands on",
+            ],
+            "openOCDPreConfigLaunchCommands": [
+                "set ESP_RTOS none"
+            ],
+            "configFiles": [
+                "board/esp32-wrover-kit-3.3v.cfg"
+            ],
+            "overrideLaunchCommands": [
+                "mon program_esp32 target/current.bin 0x10000 verify reset hex",
+                "flushregs",
+            ],
+            "postStartSessionCommands":[
+                "thb main",
+                "continue"
+            ],
+            "overrideRestartCommands": [
+                "mon program_esp32 target/current.bin 0x10000 verify reset hex",
+                "flushregs",
+                "thb main",
+                "continue",
+            ]
         },
-        // alternatively type in manually
-        {
-            "id": "examplePrompt",
-            "description": "Example:",
-            "default": "serial",
-            "type": "promptString"
-        }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -42,7 +42,7 @@
         {
             "label": "flash example",
             "type": "shell",
-            "command": "./flash -b 912600 -p /dev/ttyUSB1 -t ${input:example}",
+            "command": "./flash -b 912600 -p /dev/ttyUSB1 -t --example ${input:example}",
             "problemMatcher": {
                 "base": "$rustc",
                 "fileLocation": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,11 +2,30 @@
     // See https://go.microsoft.com/fwlink/?LinkId=733558 
     // for the documentation about the tasks.json format
     "version": "2.0.0",
+
     "tasks": [
         {
-            "label": "cargo xbuild --examples",
+            "label": "Build and Flash Example",
             "type": "shell",
-            "command": "cargo xbuild --examples",
+            "command": "./flash -t --example ${input:example}",
+            "problemMatcher": {
+                "base": "$rustc",
+                "fileLocation": [
+                    "relative"
+                ]
+            },
+            "group": "build",
+            "presentation": {
+                "reveal": "silent",
+                "panel": "shared",
+                "clear": true
+            }
+        },
+
+        {
+            "label": "Build Example",
+            "type": "shell",
+            "command": "./flash -s --example ${input:example}",
             "problemMatcher": {
                 "base": "$rustc",
                 "fileLocation": [
@@ -23,8 +42,26 @@
                 "clear": true
             }
         },
+        
         {
-            "label": "cargo xdoc --open",
+            "label": "Compile All Examples",
+            "type": "shell",
+            "command": "cargo xbuild --examples",
+            "problemMatcher": {
+                "base": "$rustc",
+                "fileLocation": [
+                    "relative"
+                ]
+            },
+            "group":  "build",
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared",
+                "clear": true
+            }
+        },
+        {
+            "label": "Build Documentation",
             "type": "shell",
             "command": "cargo xdoc --open",
             "problemMatcher": {
@@ -33,29 +70,13 @@
                     "relative"
                 ]
             },
+            "group":  "build",
             "presentation": {
                 "reveal": "silent",
                 "panel": "shared",
                 "clear": true
             }
         },
-        {
-            "label": "flash example",
-            "type": "shell",
-            "command": "./flash -b 912600 -p /dev/ttyUSB1 -t --example ${input:example}",
-            "problemMatcher": {
-                "base": "$rustc",
-                "fileLocation": [
-                    "relative"
-                ]
-            },
-            "group": "build",
-            "presentation": {
-                "reveal": "silent",
-                "panel": "shared",
-                "clear": true
-            }
-        }
     ],
     "inputs": [
         // requires Tasks Shell Input extension
@@ -64,7 +85,7 @@
             "type": "command",
             "command": "shellCommand.execute",
             "args": {
-                "command": "egrep '\\[\\[example\\]\\]|name[ \t]+=' Cargo.toml | egrep '\\[\\[example\\]\\]' -A1 | egrep 'name[ \t]*=' | sed -E 's/name[ \t]*=[ \t]*//; s/\"//g'",
+                "command": "cargo check --offline --example 2>&1 |egrep '^ '| sed -E 's/[ \t]*//g'",
                 "cwd": "${workspaceFolder}/../esp32-hal"
             }
         },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,6 +6,7 @@
         {
             "label": "Build and Flash Example",
             "type": "shell",
+            "runOptions": {"reevaluateOnRerun": false},
             "command": "./flash -t --example ${input:example}",
             "problemMatcher": {
                 "base": "$rustc",
@@ -23,6 +24,7 @@
         {
             "label": "Build Example",
             "type": "shell",
+            "runOptions": {"reevaluateOnRerun": false},
             "command": "./flash -s --example ${input:example}",
             "problemMatcher": {
                 "base": "$rustc",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,6 @@
     // See https://go.microsoft.com/fwlink/?LinkId=733558 
     // for the documentation about the tasks.json format
     "version": "2.0.0",
-
     "tasks": [
         {
             "label": "Build and Flash Example",
@@ -19,9 +18,8 @@
                 "reveal": "silent",
                 "panel": "shared",
                 "clear": true
-            }
+            },
         },
-
         {
             "label": "Build Example",
             "type": "shell",
@@ -42,7 +40,6 @@
                 "clear": true
             }
         },
-        
         {
             "label": "Compile All Examples",
             "type": "shell",
@@ -53,7 +50,7 @@
                     "relative"
                 ]
             },
-            "group":  "build",
+            "group": "build",
             "presentation": {
                 "reveal": "always",
                 "panel": "shared",
@@ -70,7 +67,7 @@
                     "relative"
                 ]
             },
-            "group":  "build",
+            "group": "build",
             "presentation": {
                 "reveal": "silent",
                 "panel": "shared",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Scott Mabin <scott@mabez.dev>", "Arjan Mels <arjan@mels.email>"]
 edition = "2018"
 
 [features]
-default=[]
+default=["external_ram"]
 
 # feature to place program completely in ram (needed when e.g. using only ROM bootloader)
 all_in_ram=[]
@@ -15,8 +15,8 @@ external_ram=["esp32-hal-proc-macros/external_ram"]
 
 [dependencies]
 esp32-hal-proc-macros = { path = "procmacros" }
-xtensa-lx6-rt = { git = "https://github.com/esp-rs/xtensa-lx6-rt.git", rev = "b5ebc04" }
 esp32 = { version = "0.3.0" }
+xtensa-lx6-rt = { git = "https://github.com/esp-rs/xtensa-lx6-rt.git", rev = "c7ae5da" }
 nb = "0.1.2"
 spin = "0.5.2"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,15 @@ version = "0.1.0"
 authors = ["Scott Mabin <scott@mabez.dev>", "Arjan Mels <arjan@mels.email>"]
 edition = "2018"
 
+[features]
+default=[]
+
+# feature to place program completely in ram (needed when e.g. using only ROM bootloader)
+all_in_ram=[]
+
+# feature to allow use of external ram. Currently not yet supported: psram needs configuration
+external_ram=["esp32-hal-proc-macros/external_ram"]
+
 [dependencies]
 esp32-hal-proc-macros = { path = "procmacros" }
 xtensa-lx6-rt = { git = "https://github.com/esp-rs/xtensa-lx6-rt.git", rev = "b5ebc04" }
@@ -27,3 +36,7 @@ name = "rtccntl"
 
 [[example]]
 name = "multicore"
+
+[[example]]
+name = "ram"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ external_ram=["esp32-hal-proc-macros/external_ram"]
 [dependencies]
 esp32-hal-proc-macros = { path = "procmacros" }
 esp32 = { version = "0.3.0" }
-xtensa-lx6-rt = { git = "https://github.com/esp-rs/xtensa-lx6-rt.git", rev = "c7ae5da" }
+xtensa-lx6-rt = { git = "https://github.com/esp-rs/xtensa-lx6-rt.git" }
 nb = "0.1.2"
 spin = "0.5.2"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
@@ -24,19 +24,3 @@ embedded-hal = { version = "0.2.3", features = ["unproven"] }
 [dev-dependencies]
 panic-halt = "0.2.0"
 spin = "0.5"
-
-[[example]]
-name = "blinky"
-
-[[example]]
-name = "serial"
-
-[[example]]
-name = "rtccntl"
-
-[[example]]
-name = "multicore"
-
-[[example]]
-name = "ram"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,3 @@ embedded-hal = { version = "0.2.3", features = ["unproven"] }
 
 [dev-dependencies]
 panic-halt = "0.2.0"
-spin = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Scott Mabin <scott@mabez.dev>", "Arjan Mels <arjan@mels.email>"]
 edition = "2018"
 
 [dependencies]
-xtensa-lx6-rt = { git = "https://github.com/esp-rs/xtensa-lx6-rt.git", rev = "62229c1" }
+esp32-hal-proc-macros = { path = "procmacros" }
+xtensa-lx6-rt = { git = "https://github.com/esp-rs/xtensa-lx6-rt.git", rev = "b5ebc04" }
 esp32 = { version = "0.3.0" }
 nb = "0.1.2"
 spin = "0.5.2"

--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,16 @@ fn main() {
         .unwrap()
         .write_all(include_bytes!("memory.x"))
         .unwrap();
+
+    File::create(out.join("alias.x"))
+        .unwrap()
+        .write_all(if cfg!(feature = "all_in_ram") {
+            include_bytes!("ram.x")
+        } else {
+            include_bytes!("rom.x")
+        })
+        .unwrap();
+
     println!("cargo:rustc-link-search={}", out.display());
 
     // Only re-run the build script when memory.x is changed,

--- a/examples/ram.rs
+++ b/examples/ram.rs
@@ -1,0 +1,209 @@
+#![no_std]
+#![no_main]
+
+use core::fmt::Write;
+use core::panic::PanicInfo;
+
+use esp32_hal::prelude::*;
+
+use esp32_hal::clock_control::{sleep, CPUSource, ClockControl, ClockControlConfig};
+use esp32_hal::dport::Split;
+use esp32_hal::dprintln;
+use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
+const BLINK_HZ: Hertz = Hertz(1);
+
+#[no_mangle]
+fn main() -> ! {
+    let dp = unsafe { esp32::Peripherals::steal() };
+
+    let mut timg0 = dp.TIMG0;
+    let mut timg1 = dp.TIMG1;
+
+    // (https://github.com/espressif/openocd-esp32/blob/97ba3a6bb9eaa898d91df923bbedddfeaaaf28c9/src/target/esp32.c#L431)
+    // openocd disables the watchdog timers on halt
+    // we will do it manually on startup
+    disable_timg_wdts(&mut timg0, &mut timg1);
+
+    let (mut dport, dport_clock_control) = dp.DPORT.split();
+
+    // setup clocks & watchdog
+    let mut clock_control = ClockControl::new(
+        dp.RTCCNTL,
+        dp.APB_CTRL,
+        dport_clock_control,
+        esp32_hal::clock_control::XTAL_FREQUENCY_AUTO,
+    )
+    .unwrap();
+
+    unsafe { esp32_hal::ESP32PreInit() };
+
+    let (clock_control_config, mut watchdog) = clock_control.freeze().unwrap();
+
+    watchdog.start(2.s());
+
+    // setup serial controller
+    let mut uart0 = Serial::uart0(
+        dp.UART0,
+        (NoTx, NoRx),
+        Config::default(),
+        clock_control_config,
+        &mut dport,
+    )
+    .unwrap();
+
+    uart0.change_baudrate(115200).unwrap();
+
+    // print startup message
+    writeln!(uart0, "\n\nReboot!\n",).unwrap();
+
+    writeln!(
+        uart0,
+        "Running on core {:0x}\n",
+        xtensa_lx6_rt::get_core_id()
+    )
+    .unwrap();
+
+    ram_tests(&mut uart0);
+
+    loop {}
+}
+
+fn attr_none_fn(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
+    writeln!(
+        uart,
+        "attr_none_fn: {:0x}",
+        xtensa_lx6_rt::get_program_counter()
+    )
+    .unwrap();
+}
+
+#[ram]
+fn attr_ram_fn(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
+    writeln!(
+        uart,
+        "attr_ram_fn: {:0x}",
+        xtensa_lx6_rt::get_program_counter()
+    )
+    .unwrap();
+}
+
+#[ram(rtc_slow)]
+fn attr_ram_fn_rtc_slow(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
+    writeln!(
+        uart,
+        "attr_ram_fn_rtc_slow: {:0x}",
+        xtensa_lx6_rt::get_program_counter()
+    )
+    .unwrap();
+}
+
+#[ram(rtc_fast)]
+fn attr_ram_fn_rtc_fast(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
+    writeln!(
+        uart,
+        "attr_ram_fn_rtc_fast: {:0x}",
+        xtensa_lx6_rt::get_program_counter()
+    )
+    .unwrap();
+}
+
+static ATTR_NONE_STATIC: [u8; 16] = *b"ATTR_NONE_STATIC";
+
+#[ram]
+static ATTR_RAM_STATIC: [u8; 15] = *b"ATTR_RAM_STATIC";
+
+#[ram(rtc_slow)]
+static ATTR_RAM_STATIC_RTC_SLOW: [u8; 24] = *b"ATTR_RAM_STATIC_RTC_SLOW";
+
+#[ram(rtc_fast)]
+static ATTR_RAM_STATIC_RTC_FAST: [u8; 24] = *b"ATTR_RAM_STATIC_RTC_FAST";
+
+#[cfg(feature = "external_ram")]
+#[ram(external)]
+static mut ATTR_RAM_STATIC_EXTERNAL: [u8; 24] = *b"ATTR_RAM_STATIC_EXTERNAL";
+
+#[cfg(feature = "external_ram")]
+#[ram(external, zeroed)]
+static mut ATTR_RAM_STATIC_EXTERNAL_BSS: [u8; 1024] = [0; 1024];
+
+fn ram_tests(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
+    attr_none_fn(uart);
+    attr_ram_fn(uart);
+    attr_ram_fn_rtc_slow(uart);
+    attr_ram_fn_rtc_fast(uart);
+
+    writeln!(
+        uart,
+        "ATTR_NONE_STATIC: {:x}: {:02x?}",
+        &ATTR_NONE_STATIC as *const u8 as usize, ATTR_NONE_STATIC
+    )
+    .unwrap();
+
+    writeln!(
+        uart,
+        "ATTR_RAM_STATIC: {:x}: {:02x?}",
+        &ATTR_RAM_STATIC as *const u8 as usize, ATTR_RAM_STATIC
+    )
+    .unwrap();
+
+    writeln!(
+        uart,
+        "ATTR_RAM_STATIC_RTC_SLOW: {:x}: {:02x?}",
+        &ATTR_RAM_STATIC_RTC_SLOW as *const u8 as usize, ATTR_RAM_STATIC_RTC_SLOW
+    )
+    .unwrap();
+
+    writeln!(
+        uart,
+        "ATTR_RAM_STATIC_RTC_FAST: {:x}: {:02x?}",
+        &ATTR_RAM_STATIC_RTC_FAST as *const u8 as usize, ATTR_RAM_STATIC_RTC_FAST
+    )
+    .unwrap();
+
+    if cfg!(feature = "external_ram") {
+        external_ram();
+    }
+}
+
+#[cfg(not(feature = "external_ram"))]
+fn external_ram() {}
+
+#[cfg(feature = "external_ram")]
+fn external_ram() {
+    unsafe {
+        writeln!(
+            uart,
+            "ATTR_RAM_STATIC_EXTERNAL: {:x}: {:02x?}",
+            &ATTR_RAM_STATIC_EXTERNAL as *const u8 as usize, ATTR_RAM_STATIC_EXTERNAL
+        )
+        .unwrap();
+
+        writeln!(
+            uart,
+            "ATTR_RAM_STATIC_EXTERNAL_BSS: {:x}: {:02x?}",
+            &ATTR_RAM_STATIC_EXTERNAL_BSS as *const u8 as usize,
+            &ATTR_RAM_STATIC_EXTERNAL_BSS[0..20]
+        )
+        .unwrap();
+    }
+}
+
+const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
+
+fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
+    timg0
+        .wdtwprotect
+        .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });
+    timg1
+        .wdtwprotect
+        .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });
+
+    timg0.wdtconfig0.write(|w| unsafe { w.bits(0x0) });
+    timg1.wdtconfig0.write(|w| unsafe { w.bits(0x0) });
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    dprintln!("\n\n*** {:?}", info);
+    loop {}
+}

--- a/examples/ram.rs
+++ b/examples/ram.rs
@@ -72,7 +72,7 @@ fn main() -> ! {
 fn attr_none_fn(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
     writeln!(
         uart,
-        "{:<40}: {:0x}",
+        "{:<40}: {:0x?}",
         "attr_none_fn",
         xtensa_lx6_rt::get_program_counter()
     )
@@ -83,7 +83,7 @@ fn attr_none_fn(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>
 fn attr_ram_fn(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
     writeln!(
         uart,
-        "{:<40}: {:0x}",
+        "{:<40}: {:0x?}",
         "attr_ram_fn",
         xtensa_lx6_rt::get_program_counter()
     )
@@ -94,7 +94,7 @@ fn attr_ram_fn(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>)
 fn attr_ram_fn_rtc_slow(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
     writeln!(
         uart,
-        "{:<40}: {:0x}",
+        "{:<40}: {:0x?}",
         "attr_ram_fn_rtc_slow",
         xtensa_lx6_rt::get_program_counter()
     )
@@ -105,7 +105,7 @@ fn attr_ram_fn_rtc_slow(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx
 fn attr_ram_fn_rtc_fast(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
     writeln!(
         uart,
-        "{:<40}: {:0x}",
+        "{:<40}: {:0x?}",
         "attr_ram_fn_rtc_fast",
         xtensa_lx6_rt::get_program_counter()
     )

--- a/examples/ram.rs
+++ b/examples/ram.rs
@@ -174,14 +174,14 @@ macro_rules! print_info {
 }
 
 fn ram_tests(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
-    writeln!(uart);
+    writeln!(uart).unwrap();
 
     attr_none_fn(uart);
     attr_ram_fn(uart);
     attr_ram_fn_rtc_slow(uart);
     attr_ram_fn_rtc_fast(uart);
 
-    writeln!(uart);
+    writeln!(uart).unwrap();
 
     unsafe {
         print_info!(uart, ATTR_NONE_STATIC);
@@ -206,7 +206,7 @@ fn ram_tests(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
         external_ram(uart);
     }
 
-    writeln!(uart);
+    writeln!(uart).unwrap();
 }
 
 #[cfg(not(feature = "external_ram"))]

--- a/examples/rtccntl.rs
+++ b/examples/rtccntl.rs
@@ -63,8 +63,6 @@ fn main() -> ! {
 
     uart0.change_baudrate(115200).unwrap();
 
-    uart0.change_baudrate_force_clock(115200, true).unwrap();
-
     // print startup message
     writeln!(uart0, "\n\nReboot!\n",).unwrap();
 

--- a/flash
+++ b/flash
@@ -187,6 +187,13 @@ echo
 # convert to bin
 rm $BIN_PATH.bin 2>/dev/null
 esptool.py --chip esp32 elf2image --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED  -o $BIN_PATH.bin $BIN_PATH > /dev/null
+if [ $? -ne 0 ]
+then
+    printf "${ERROR}Error: Output file ($BIN_PATH).bin not generated!${RESET}\n\n"
+    esptool.py --chip esp32 elf2image --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED  -o $BIN_PATH.bin $BIN_PATH
+    exit 1
+fi
+
 esptool.py --chip esp32 image_info $BIN_PATH.bin |egrep -v -i "esptool.py|Image version|Checksum|Validation Hash|Segments"
 echo
 

--- a/flash
+++ b/flash
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-# port esp32 is connected to
-PORT=/dev/ttyUSB0
+# port esp32 is connected to (leave empty to autodetect)
+PORT=
+#PORT=/dev/ttyUSB1
 
 # baud rate for programming
-FLASH_BAUDRATE=115200
+FLASH_BAUDRATE=921600
 
 # baud rate for terminal
 TERM_BAUDRATE=115200
@@ -36,29 +37,34 @@ BOOTLOADER_SOURCE=https://github.com/arjanmels/esp32_bootloader_init_extram/blob
 # default bootloader from the espressif arduino github
 #BOOTLOADER_SOURCE=https://github.com/espressif/arduino-esp32/blob/idf-release/v4.0/tools/sdk/bin/bootloader_dio_40m.bin?raw=true
 
+# color codes
+STAGE="\033[1;36m"
+SUCCESS="\033[1;32m"
+ERROR="\033[1;31m"
+RESET="\033[0m"
 
-# set to build example
-EXAMPLE=""
 
 
 showhelp() {
 cat << EOF
-Usage: flash -hrtb -p <serial port> <example>
+Usage: flash -hrtbs [-p <serial port>] [-e <example>]
 
 -h, --help                      Display Help
 -r, --release                   Build in release mode
--p, --port <serial port>        Set serial port (default: $PORT)
+-p, --port <serial port>        Set serial port (default: autodetect)
 -b, --baudrate <baudrate>       Set baudrate for flasing (default: $FLASH_BAUDRATE)
   , --termbaudrate <baudrate>   Set baudrate for monitoring (default: $TERM_BAUDRATE)
 -t, --terminal                  Open terminal program after flashing
 -e, --example <example>         Build the specified example
+-s, --skip                      Skip actual flashing
 EOF
 }
 
 # get command line options
-options=$(getopt -l "help,release,port:,terminal,baudrate:,termbaudrate:,example:" -o "hrp:tb:e:" -a -- "$@")
+options=$(getopt -l "help,release,port:,terminal,baudrate:,termbaudrate:,example:,skip" -o "hrp:tb:e:s" -a -- "$@")
 
-if [ $? -ne 0 ]; then
+if [[ $? -ne 0 ]]
+then
     echo
     showhelp
     exit 1
@@ -80,6 +86,9 @@ do
     -p|--port)
         shift
         export PORT=$1
+        ;;
+    -s|--skip)
+        export SKIPFLASH=1
         ;;
     -t|--terminal)
         export TERMINAL=1
@@ -103,21 +112,21 @@ do
 shift
 done
 
-if [[ $# -ne 0 ]] ;
+if [[ $# -ne 0 ]]
 then
-    echo "*** Wrong number of arguments" >&2
-    echo
+    printf "${ERROR}*** Wrong number of arguments${RESET}\n\n" >&2
     showhelp
     exit 1
 fi
 
-if [[ ! -f Cargo.toml ]] ;
+if [[ ! -f Cargo.toml ]]
 then
-    echo "*** Must be run in root of project where Cargo.toml file is located" >&2
+    printf "${ERROR}*** Must be run in root of project where Cargo.toml file is located${RESET}\n" >&2
     exit 1
 fi
 
-if [ -z "$EXAMPLE" ]; then
+if [[ -z "$EXAMPLE" ]]
+then
     FILE=$(awk 'BEGIN {FS="[ \t=\"]+";} /^\s*\[/ {section=$1} tolower(section)=="[package]" && tolower($0) ~ /^\s*name/ {print $2}' Cargo.toml)
     BIN_PATH=target/xtensa-esp32-none-elf/$TYPE/$FILE
     EXAMPLE_ARG=""
@@ -126,16 +135,41 @@ else
     EXAMPLE_ARG="--example "$EXAMPLE
 fi
 
-# build the specific example
+# create links to output binaries for linking with debugger
+ln -sf $(pwd)/$BIN_PATH target/current.elf; 
+ln -sf $(pwd)/$BIN_PATH.bin target/current.bin
+
+# set the release flag
 if [ "$TYPE" = "release" ]
 then 
-    cargo xbuild --release $EXAMPLE_ARG
+    RELEASE="--release"
 else
-    cargo xbuild $EXAMPLE_ARG
+    RELEASE=""
 fi
 
-# if cargo returned an error quit the script
-if [ $? -ne 0 ]; then
+CMD="cargo xbuild $RELEASE $EXAMPLE_ARG"
+
+printf "${STAGE}Building application with $CMD...${RESET}\n\n"
+
+# get error code of any step of the pipe
+set -o pipefail
+
+# run cargo & get missing features
+{ FEATURES=$(eval $CMD --color always 3>&2 2>&1 | tee /dev/stderr | egrep  -o '\-\-features=".*"'; exit ${PIPESTATUS[0]}); } 3>&1
+RES=$?
+
+# if cargo returned an error because features are missing to rerun
+if [[ $RES -ne 0 && -n $FEATURES ]]
+then
+    CMD="cargo xbuild $RELEASE $EXAMPLE_ARG $FEATURES"
+    printf "\n\n${STAGE}Building application with $CMD...${RESET}\n\n"
+    eval $CMD
+    RES=$?
+fi
+
+# if cargo returned an error exit
+if [[ $RES -ne 0 ]]
+then
     exit 1
 fi
 
@@ -146,46 +180,92 @@ echo
 
 # convert to bin
 rm $BIN_PATH.bin 2>/dev/null
-esptool.py --chip esp32 elf2image --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED  -o $BIN_PATH.bin $BIN_PATH
-esptool.py --chip esp32 image_info $BIN_PATH.bin
+esptool.py --chip esp32 elf2image --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED  -o $BIN_PATH.bin $BIN_PATH > /dev/null
+esptool.py --chip esp32 image_info $BIN_PATH.bin |egrep -v -i "esptool.py|Image version|Checksum|Validation Hash|Segments"
 echo
 
-if [ $? -ne 0 ]; then
+if [ $? -ne 0 ]
+then
     exit 1
 fi
 
-# kill terminal programs using the same port
-ps -ef|grep $PORT|egrep -v "$0|grep" |awk '{print $2}'|xargs -r kill
-
-if [[ !USE_BOOTLOADER -eq 1 ]] ; then
-    esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x1000 $BIN_PATH.bin
-else
-    # get gen_esp32part.py and create binary partition table
-    curl -s -S -L $GENPART_SOURCE --output target/gen_esp32part.py
-    
-    rm target/partitions.bin 2> /dev/null
-    python target/gen_esp32part.py partitions.csv target/partitions.bin 
-
-    # get bootloader.bin file (from arduino-esp32 repository)
-    # (different variants exist, but only difference is flash settings which are overriden by esptool)
-    curl -s -S -L $BOOTLOADER_SOURCE --output target/bootloader.bin
-
-    # check if bootloader.bin and paritions.bin are already correctly flashed (to prevent unnecessary writes)
-    esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset verify_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x1000 target/bootloader.bin $PARTION_ADDR target/partitions.bin
-    if [ $? -ne 0 ]; then
-        # flash bootloader.bin, partitions.bin and application
-        esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x1000 target/bootloader.bin $PARTION_ADDR target/partitions.bin $APP_ADDR $BIN_PATH.bin
+if [[ $SKIPFLASH -ne 1 || $TERMINAL -eq 1 ]]
+then
+    if [[ -z "$PORT" ]]
+    then
+        # kill terminal programs using any port
+        ps -ef|grep "/dev/ttyUSB" |egrep -v "$0|grep" |awk '{print $2}'|xargs -r kill
+        printf "${STAGE}Detecting port...${RESET} "
+        PORT=$(esptool.py --no-stub read_mac 2> /dev/null | awk '/^Serial port / {port=$3} END {print port}')
+        if [[ -z $PORT ]]
+        then
+            printf "${ERROR}Error: cannot detect port!${RESET}\n\n"
+            exit 1
+        fi
+        printf "$PORT\n\n"
     else
-        # flash application only
-        esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect $APP_ADDR $BIN_PATH.bin
+        # kill terminal programs using the same port
+        ps -ef|grep $PORT|egrep -v "$0|grep" |awk '{print $2}'|xargs -r kill
     fi
 fi
 
+if [[ $SKIPFLASH -ne 1 ]]
+then
+    flash() {
+        echo -e "${STAGE}Flashing...${RESET} $@\n"
+        esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect ${@} |egrep -v -i "stub|baud rate|Changed.|Configuring flash size|Serial port|esptool.py|Leaving"
+    }
+
+    if [[ !USE_BOOTLOADER -eq 1 ]]
+    then
+        flash 0x1000 $BIN_PATH.bin 
+    else
+        printf "${STAGE}Creating partition table...${RESET}\n\n"
+
+        # get gen_esp32part.py and create binary partition table
+        curl -s -S -L $GENPART_SOURCE --output target/gen_esp32part.py
+        
+        rm target/partitions.bin 2> /dev/null
+        python target/gen_esp32part.py partitions.csv target/partitions.bin
+
+        echo
+
+        # get bootloader.bin file 
+        # (different variants exist, but only difference is flash settings which are overriden by esptool)
+        curl -s -S -L $BOOTLOADER_SOURCE --output target/bootloader.bin
+        
+        # check if bootloader.bin and paritions.bin are already correctly flashed (to prevent unnecessary writes)
+        printf "${STAGE}Verify bootloader and partition table...${RESET} "
+        esptool.py --no-stub --chip esp32 --port $PORT --baud $FLASH_BAUDRATE verify_flash 0x1000 target/bootloader.bin $PARTION_ADDR target/partitions.bin > /dev/null
+        if [ $? -ne 0 ]; then
+            printf "modified.\n\n"
+            # flash bootloader.bin, partitions.bin and application
+            flash 0x1000 target/bootloader.bin $PARTION_ADDR target/partitions.bin $APP_ADDR $BIN_PATH.bin
+        else
+            printf "unchanged.\n\n"
+            # flash application only
+            flash $APP_ADDR $BIN_PATH.bin  
+        fi
+    fi
+
+    if [[ $? -ne 0 ]]
+    then
+        printf "\n${ERROR}Error flashing application${RESET}\n\n"
+        exit 1
+    fi
+fi
 
 # start terminal program
 if [[ TERMINAL -eq 1 ]]
 then
-    echo
-    echo "Starting terminal"
+    printf "\n${STAGE}Starting terminal.${RESET}\n"
     gnome-terminal --geometry 200x15+0+2000 -- picocom -b $TERM_BAUDRATE $PORT --imap lfcrlf 2>/dev/null
+fi
+
+
+if [[ $SKIPFLASH -ne 1 ]]
+then
+    printf "\n${SUCCESS}Succesfully build and flashed application${RESET}\n\n"
+else
+    printf "\n${SUCCESS}Succesfully build application${RESET}\n\n"
 fi

--- a/flash
+++ b/flash
@@ -15,7 +15,7 @@ FLASH_MODE="dio"
 # Flash Speed
 FLASH_SPEED="40m"
 
-# Use bootloader
+# Use bootloader (needed for using irom, drom and psram)
 USE_BOOTLOADER=1
 
 
@@ -111,6 +111,8 @@ echo
 # convert to bin
 rm $BIN_PATH.bin 2>/dev/null
 esptool.py --chip esp32 elf2image --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED  -o $BIN_PATH.bin $BIN_PATH
+esptool.py --chip esp32 image_info $BIN_PATH.bin
+echo
 
 if [ $? -ne 0 ]; then
     exit 1
@@ -119,10 +121,12 @@ fi
 # kill terminal programs using the same port
 ps -ef|grep $PORT|egrep -v "$0|grep" |awk '{print $2}'|xargs -r kill
 
-if [[ -v USE_BOOTLOADER ]]
+if [[ USE_BOOTLOADER -eq 1 ]]
 then
     # get gen_esp32part.py and create binary partition table
     curl -s -S -L -C - https://github.com/espressif/esp-idf/raw/release/v4.1/components/partition_table/gen_esp32part.py?raw=true --output target/gen_esp32part.py
+    
+    rm target/partitions.bin > /dev/null
     python target/gen_esp32part.py partitions.csv target/partitions.bin 
 
     # get bootloader.bin file (from arduino-esp32 repository)
@@ -142,8 +146,10 @@ else
         esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x1000 $BIN_PATH.bin
 fi
 
+
+
 # start terminal program
-if [[ -v TERMINAL ]]
+if [[ TERMINAL -eq 1 ]]
 then
     echo
     echo "Starting terminal"

--- a/flash
+++ b/flash
@@ -157,9 +157,9 @@ fi
 # kill terminal programs using the same port
 ps -ef|grep $PORT|egrep -v "$0|grep" |awk '{print $2}'|xargs -r kill
 
-if [[ !USE_BOOTLOADER -eq 1 ]]
+if [[ !USE_BOOTLOADER -eq 1 ]] ; then
     esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x1000 $BIN_PATH.bin
-then
+else
     # get gen_esp32part.py and create binary partition table
     curl -s -S -L $GENPART_SOURCE --output target/gen_esp32part.py
     
@@ -180,7 +180,6 @@ then
         esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect $APP_ADDR $BIN_PATH.bin
     fi
 fi
-
 
 
 # start terminal program

--- a/flash
+++ b/flash
@@ -135,10 +135,6 @@ else
     EXAMPLE_ARG="--example "$EXAMPLE
 fi
 
-# create links to output binaries for linking with debugger
-ln -sf $(pwd)/$BIN_PATH target/current.elf; 
-ln -sf $(pwd)/$BIN_PATH.bin target/current.bin
-
 # set the release flag
 if [ "$TYPE" = "release" ]
 then 
@@ -150,6 +146,10 @@ fi
 CMD="cargo xbuild $RELEASE $EXAMPLE_ARG"
 
 printf "${STAGE}Building application with $CMD...${RESET}\n\n"
+
+rm target/current.elf 2> /dev/null
+rm target/current.bin 2> /dev/null
+
 
 # get error code of any step of the pipe
 set -o pipefail
@@ -194,6 +194,10 @@ if [ $? -ne 0 ]
 then
     exit 1
 fi
+
+# create links to output binaries for linking with debugger
+ln -sf $(pwd)/$BIN_PATH target/current.elf
+ln -sf $(pwd)/$BIN_PATH.bin target/current.bin
 
 if [[ $SKIPFLASH -ne 1 || $TERMINAL -eq 1 ]]
 then

--- a/flash
+++ b/flash
@@ -220,29 +220,36 @@ then
     then
         flash 0x1000 $BIN_PATH.bin 
     else
-        printf "${STAGE}Creating partition table...${RESET}\n\n"
 
-        # get gen_esp32part.py and create binary partition table
-        curl -s -S -L $GENPART_SOURCE --output target/gen_esp32part.py
-        
-        rm target/partitions.bin 2> /dev/null
-        python target/gen_esp32part.py partitions.csv target/partitions.bin
+        printf "${STAGE}Creating partition table... ${RESET}"
+        if [[ target/partitions.bin -ot partitions.csv ]]
+        then
+            printf "\n\n"
+            # get gen_esp32part.py and create binary partition table
+            curl -s -S -L $GENPART_SOURCE --output target/gen_esp32part.py
+            
+            rm target/partitions.bin 2> /dev/null
+            python target/gen_esp32part.py partitions.csv target/partitions.bin
+    
+            echo
+        else
+            printf "skipping as it is up to date\n\n"
+        fi
 
-        echo
 
         # get bootloader.bin file 
         # (different variants exist, but only difference is flash settings which are overriden by esptool)
         curl -s -S -L $BOOTLOADER_SOURCE --output target/bootloader.bin
-        
+
         # check if bootloader.bin and paritions.bin are already correctly flashed (to prevent unnecessary writes)
         printf "${STAGE}Verify bootloader and partition table...${RESET} "
         esptool.py --no-stub --chip esp32 --port $PORT --baud $FLASH_BAUDRATE verify_flash 0x1000 target/bootloader.bin $PARTION_ADDR target/partitions.bin > /dev/null
         if [ $? -ne 0 ]; then
-            printf "modified.\n\n"
+            printf "modified\n\n"
             # flash bootloader.bin, partitions.bin and application
             flash 0x1000 target/bootloader.bin $PARTION_ADDR target/partitions.bin $APP_ADDR $BIN_PATH.bin
         else
-            printf "unchanged.\n\n"
+            printf "unchanged\n\n"
             # flash application only
             flash $APP_ADDR $BIN_PATH.bin  
         fi

--- a/flash
+++ b/flash
@@ -9,6 +9,16 @@ FLASH_BAUDRATE=115200
 # baud rate for terminal
 TERM_BAUDRATE=115200
 
+# Flash Mode
+FLASH_MODE="dio"
+
+# Flash Speed
+FLASH_SPEED="40m"
+
+# Use bootloader
+USE_BOOTLOADER=1
+
+
 # debug or release build
 TYPE=debug
 
@@ -19,8 +29,8 @@ Usage: flash -hrtb -p <serial port> <example>
 -h, --help                      Display Help
 -r, --release                   Build in release mode
 -p, --port <serial port>        Set serial port (default: $PORT)
--b, --baudrate <baudrate>       Set baudrate for flasinh (default: $FLASH_BAUDRATE)
-  , --termbaudrate <baudrate>   Set baudrate for flasinh (default: $FLASH_BAUDRATE)
+-b, --baudrate <baudrate>       Set baudrate for flasing (default: $FLASH_BAUDRATE)
+  , --termbaudrate <baudrate>   Set baudrate for monitoring (default: $TERM_BAUDRATE)
 -t, --terminal                  Open terminal program after flashing
 EOF
 }
@@ -93,21 +103,44 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-#display section seizes
+#display section sizes
 echo
 xtensa-esp32-elf-readelf $BIN_PATH -S|egrep 'BIT|\[Nr\]' |awk 'BEGIN {FS="[ \t\[\]]+"}  $9~/A|Flg/ {size=sprintf("%7d", "0x" $7)+0; printf("%-3s %-20s %-8s %-8s %-8s %8s %-3s %-3s\n",$2,$3,$4,$5,$7,((size>0)?size:$7),$9,$12); total+=size; } END { printf("\nTotal: %d bytes\n",total)}'
 echo
 
-
 # convert to bin
-rm $BIN_PATH.bin > /dev/null
-esptool --chip esp32 elf2image --flash_mode="dio" --flash_freq "40m" --flash_size "4MB" -o $BIN_PATH.bin $BIN_PATH
+rm $BIN_PATH.bin 2>/dev/null
+esptool.py --chip esp32 elf2image --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED  -o $BIN_PATH.bin $BIN_PATH
+
+if [ $? -ne 0 ]; then
+    exit 1
+fi
 
 # kill terminal programs using the same port
 ps -ef|grep $PORT|egrep -v "$0|grep" |awk '{print $2}'|xargs -r kill
 
-# flash
-esptool --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size detect 0x1000 $BIN_PATH.bin
+if [[ -v USE_BOOTLOADER ]]
+then
+    # get gen_esp32part.py and create binary partition table
+    curl -s -S -L -C - https://github.com/espressif/esp-idf/raw/release/v4.1/components/partition_table/gen_esp32part.py?raw=true --output target/gen_esp32part.py
+    python target/gen_esp32part.py partitions.csv target/partitions.bin 
+
+    # get bootloader.bin file (from arduino-esp32 repository)
+    # (different variants exist, but only difference is flash settings which are overriden by esptool)
+    curl -s -S -L -C - https://github.com/espressif/arduino-esp32/blob/idf-release/v4.0/tools/sdk/bin/bootloader_dio_40m.bin?raw=true --output target/bootloader.bin
+
+    # check if bootloader.bin and paritions.bin are already correctly flashed (to prevent unneceesary writes)
+    esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset verify_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x1000 target/bootloader.bin 0x8000 target/partitions.bin
+    if [ $? -ne 0 ]; then
+        # flash bootloader.bin, partitions.bin and application
+        esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x1000 target/bootloader.bin 0x8000 target/partitions.bin 0x10000 $BIN_PATH.bin
+    else
+        # flash application only
+        esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x10000 $BIN_PATH.bin
+    fi
+else
+        esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x1000 $BIN_PATH.bin
+fi
 
 # start terminal program
 if [[ -v TERMINAL ]]

--- a/flash
+++ b/flash
@@ -155,7 +155,7 @@ printf "${STAGE}Building application with $CMD...${RESET}\n\n"
 set -o pipefail
 
 # run cargo & get missing features
-{ FEATURES=$(eval $CMD --color always 3>&2 2>&1 | tee /dev/stderr | egrep  -o '\-\-features=".*"'; exit ${PIPESTATUS[0]}); } 3>&1
+{ FEATURES=$(script -efqc "$CMD 2>&1" /dev/null | tee /dev/stderr | egrep  -o '\-\-features=".*"'; exit ${PIPESTATUS[0]}); }
 RES=$?
 
 # if cargo returned an error because features are missing to rerun
@@ -170,6 +170,12 @@ fi
 # if cargo returned an error exit
 if [[ $RES -ne 0 ]]
 then
+    exit 1
+fi
+
+if [[ ! -f $BIN_PATH ]]
+then
+    printf "${ERROR}Error: Output file ($BIN_PATH) not generated!${RESET}\n\n"
     exit 1
 fi
 

--- a/flash
+++ b/flash
@@ -18,9 +18,10 @@ FLASH_SPEED="40m"
 # Use bootloader (needed for using irom, drom and psram)
 USE_BOOTLOADER=1
 
-
 # debug or release build
 TYPE=debug
+
+EXAMPLE=""
 
 showhelp() {
 cat << EOF
@@ -32,11 +33,12 @@ Usage: flash -hrtb -p <serial port> <example>
 -b, --baudrate <baudrate>       Set baudrate for flasing (default: $FLASH_BAUDRATE)
   , --termbaudrate <baudrate>   Set baudrate for monitoring (default: $TERM_BAUDRATE)
 -t, --terminal                  Open terminal program after flashing
+-e, --example <example>         Build the specified example
 EOF
 }
 
 # get command line options
-options=$(getopt -l "help,release,port:,terminal,baudrate:,termbaudrate:" -o "hrp:tb:" -a -- "$@")
+options=$(getopt -l "help,release,port:,terminal,baudrate:,termbaudrate:,example:" -o "hrp:tb:e:" -a -- "$@")
 
 if [ $? -ne 0 ]; then
     echo
@@ -72,6 +74,10 @@ do
         shift
         export TERM_BAUDRATE=$1
         ;;
+    -e|--example)
+        shift
+        export EXAMPLE=$1
+        ;;
     --)
         shift
         break;;
@@ -79,7 +85,7 @@ do
 shift
 done
 
-if [[ $# -ne 1 ]]
+if [[ $# -ne 0 ]] ;
 then
     echo "*** Wrong number of arguments" >&2
     echo
@@ -87,15 +93,27 @@ then
     exit 1
 fi
 
-# change this for release flashes
-BIN_PATH=target/xtensa-esp32-none-elf/$TYPE/examples/$1
+if [[ ! -f Cargo.toml ]] ;
+then
+    echo "*** Must be run in root of project where Cargo.toml file is located" >&2
+    exit 1
+fi
+
+if [ -z "$EXAMPLE" ]; then
+    FILE=$(awk 'BEGIN {FS="[ \t=\"]+";} /^\s*\[/ {section=$1} tolower(section)=="[package]" && tolower($0) ~ /^\s*name/ {print $2}' Cargo.toml)
+    BIN_PATH=target/xtensa-esp32-none-elf/$TYPE/$FILE
+    EXAMPLE_ARG=""
+else 
+    BIN_PATH=target/xtensa-esp32-none-elf/$TYPE/examples/$EXAMPLE
+    EXAMPLE_ARG="--example "$EXAMPLE
+fi
 
 # build the specific example
 if [ "$TYPE" = "release" ]
 then 
-    cargo xbuild --example $1 --release
+    cargo xbuild --release $EXAMPLE_ARG
 else
-    cargo xbuild --example $1
+    cargo xbuild $EXAMPLE_ARG
 fi
 
 # if cargo returned an error quit the script
@@ -126,7 +144,7 @@ then
     # get gen_esp32part.py and create binary partition table
     curl -s -S -L -C - https://github.com/espressif/esp-idf/raw/release/v4.1/components/partition_table/gen_esp32part.py?raw=true --output target/gen_esp32part.py
     
-    rm target/partitions.bin > /dev/null
+    rm target/partitions.bin 2> /dev/null
     python target/gen_esp32part.py partitions.csv target/partitions.bin 
 
     # get bootloader.bin file (from arduino-esp32 repository)

--- a/flash
+++ b/flash
@@ -21,7 +21,25 @@ USE_BOOTLOADER=1
 # debug or release build
 TYPE=debug
 
+# address of partition table
+PARTION_ADDR=0x8000
+
+# address of application
+APP_ADDR=0x10000
+
+#source of the utility to generate the binary partition table
+GENPART_SOURCE=https://github.com/espressif/esp-idf/blob/v4.0/components/partition_table/gen_esp32part.py?raw=true
+
+# source of the bootloader
+# customized bootloader which initializes the external psram
+BOOTLOADER_SOURCE=https://github.com/arjanmels/esp32_bootloader_init_extram/blob/v1.0/build/bootloader/bootloader.bin?raw=true
+# default bootloader from the espressif arduino github
+#BOOTLOADER_SOURCE=https://github.com/espressif/arduino-esp32/blob/idf-release/v4.0/tools/sdk/bin/bootloader_dio_40m.bin?raw=true
+
+
+# set to build example
 EXAMPLE=""
+
 
 showhelp() {
 cat << EOF
@@ -139,29 +157,28 @@ fi
 # kill terminal programs using the same port
 ps -ef|grep $PORT|egrep -v "$0|grep" |awk '{print $2}'|xargs -r kill
 
-if [[ USE_BOOTLOADER -eq 1 ]]
+if [[ !USE_BOOTLOADER -eq 1 ]]
+    esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x1000 $BIN_PATH.bin
 then
     # get gen_esp32part.py and create binary partition table
-    curl -s -S -L -C - https://github.com/espressif/esp-idf/raw/release/v4.1/components/partition_table/gen_esp32part.py?raw=true --output target/gen_esp32part.py
+    curl -s -S -L $GENPART_SOURCE --output target/gen_esp32part.py
     
     rm target/partitions.bin 2> /dev/null
     python target/gen_esp32part.py partitions.csv target/partitions.bin 
 
     # get bootloader.bin file (from arduino-esp32 repository)
     # (different variants exist, but only difference is flash settings which are overriden by esptool)
-    curl -s -S -L -C - https://github.com/espressif/arduino-esp32/blob/idf-release/v4.0/tools/sdk/bin/bootloader_dio_40m.bin?raw=true --output target/bootloader.bin
+    curl -s -S -L $BOOTLOADER_SOURCE --output target/bootloader.bin
 
     # check if bootloader.bin and paritions.bin are already correctly flashed (to prevent unneceesary writes)
-    esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset verify_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x1000 target/bootloader.bin 0x8000 target/partitions.bin
+    esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset verify_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x1000 target/bootloader.bin $PARTION_ADDR target/partitions.bin
     if [ $? -ne 0 ]; then
         # flash bootloader.bin, partitions.bin and application
-        esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x1000 target/bootloader.bin 0x8000 target/partitions.bin 0x10000 $BIN_PATH.bin
+        esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x1000 target/bootloader.bin $PARTION_ADDR target/partitions.bin $APP_ADDR $BIN_PATH.bin
     else
         # flash application only
-        esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x10000 $BIN_PATH.bin
+        esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect $APP_ADDR $BIN_PATH.bin
     fi
-else
-        esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset write_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x1000 $BIN_PATH.bin
 fi
 
 

--- a/flash
+++ b/flash
@@ -170,7 +170,7 @@ else
     # (different variants exist, but only difference is flash settings which are overriden by esptool)
     curl -s -S -L $BOOTLOADER_SOURCE --output target/bootloader.bin
 
-    # check if bootloader.bin and paritions.bin are already correctly flashed (to prevent unneceesary writes)
+    # check if bootloader.bin and paritions.bin are already correctly flashed (to prevent unnecessary writes)
     esptool.py --chip esp32 --port $PORT --baud $FLASH_BAUDRATE --before default_reset --after hard_reset verify_flash --flash_mode=$FLASH_MODE --flash_freq $FLASH_SPEED --flash_size detect 0x1000 target/bootloader.bin $PARTION_ADDR target/partitions.bin
     if [ $? -ne 0 ]; then
         # flash bootloader.bin, partitions.bin and application

--- a/memory.x
+++ b/memory.x
@@ -1,11 +1,58 @@
+  /* This memory map assumes the flash cache is on; 
+     the blocks used are excluded from the various memory ranges 
+     
+     see: https://github.com/espressif/esp-idf/blob/master/components/soc/src/esp32/soc_memory_layout.c
+     for details
+     */
+
+RESERVE_DRAM = 0;
+RESERVE_RTC_FAST = 0;
+RESERVE_RTC_SLOW = 0;
+
+SECTIONS {
+  .rwtext :
+  {
+    *(.rwtext.literal .rwtext .rwtext.literal.* .rwtext.*)
+  } > iram_seg
+}
+
 /* Specify main memory areas */
 MEMORY
 {
-  /* Use values from the ESP-IDF 'bootloader' component.
-  /* TODO: Use human-readable lengths */
-  /* TODO: Use the full memory map - this is just a test */
-  /* vectors ( RX )       : ORIGIN = 0x40080000, len = 0x400 */
-  iram_seg ( RX )       : ORIGIN = 0x40080400, len = 0x1fC00
-  dram_seg ( RW )       : ORIGIN = 0x3FFB0000, len = 0x2c200
+  
+  reserved1_seg ( RWX )  : ORIGIN = 0x40070000, len = 0x10000 /* SRAM0 64kB; reserved for usage as flash cache*/
+  vectors ( RX )         : ORIGIN = 0x40080000, len = 0x400 /* SRAM0 1kB */
+  iram_seg ( RX )        : ORIGIN = 0x40080400, len = 0x20000-0x400 /* SRAM0 127kB */
 
+  reserved2_seg ( RW )   : ORIGIN = 0x3FFAE000, len = 0x2000 /* SRAM2 8kB; reserved for usage by the ROM */
+  dram_seg ( RW )        : ORIGIN = 0x3FFB0000 + RESERVE_DRAM, len = 0x2c200 - RESERVE_DRAM /* SRAM2+1 176.5kB; first 64kB used by BT if enable */
+  reserved3_seg ( RW )   : ORIGIN = 0x3FFDC200, len = 0x23e00 /* SRAM1 143.5kB; reserved for static ROM usage; can be used for heap */
+
+  /* external flash 
+     The 0x20 offset is a convenience for the app binary image generation.
+     Flash cache has 64KB pages. The .bin file which is flashed to the chip
+     has a 0x18 byte file header, and each segment has a 0x08 byte segment
+     header. Setting this offset makes it simple to meet the flash cache MMU's
+     constraint that (paddr % 64KB == vaddr % 64KB).)
+  */
+  irom_seg ( RX )        : ORIGIN = 0x400D8020, len = 0x330000-0x20 /* 3MB */
+  drom_seg ( R )         : ORIGIN = 0x3F400020, len = 0x400000-0x20 /* 4MB */
+
+
+  /* RTC fast memory (executable). Persists over deep sleep. Only for core 0 (PRO_CPU) */
+  rtc_fast_iram_seg(RWX) : ORIGIN = 0x400C0000, len = 0x2000 /* 8kB */
+
+  /* RTC fast memory (same block as above), viewed from data bus. Only for core 0 (PRO_CPU) */
+  rtc_fast_dram_seg(RW)  : ORIGIN = 0x3ff80000 + RESERVE_RTC_FAST, len = 0x2000 - RESERVE_RTC_FAST /* 8kB */
+
+  /* RTC slow memory (data accessible). Persists over deep sleep. */
+  rtc_slow_seg(RW)       : ORIGIN = 0x50000000 + RESERVE_RTC_SLOW, len = 0x2000 - RESERVE_RTC_SLOW /* 8kB */
+
+  /* external memory, including data and text, 
+     4MB is the maximum, if external psram is bigger, paging is required */
+  psram_seg(RWX)         : ORIGIN = 0x3F800000, len = 0x400000 /* 4MB */
 }
+
+REGION_ALIAS("ROTEXT", irom_seg);
+REGION_ALIAS("RODATA", drom_seg);
+REGION_ALIAS("RWDATA", dram_seg);

--- a/memory.x
+++ b/memory.x
@@ -1,11 +1,17 @@
-  /* This memory map assumes the flash cache is on; 
-     the blocks used are excluded from the various memory ranges 
-     
-     see: https://github.com/espressif/esp-idf/blob/master/components/soc/src/esp32/soc_memory_layout.c
-     for details
-     */
+/* This memory map assumes the flash cache is on; 
+   the blocks used are excluded from the various memory ranges 
+   
+   see: https://github.com/espressif/esp-idf/blob/master/components/soc/src/esp32/soc_memory_layout.c
+   for details
+   */
 
+/* override entry point */
+ENTRY(ESP32Reset)
+
+/* reserved at the start of DRAM for e.g. teh BT stack */
 RESERVE_DRAM = 0;
+
+/* reserved at the start of the RTC memories for use by the ULP processor */
 RESERVE_RTC_FAST = 0;
 RESERVE_RTC_SLOW = 0;
 
@@ -47,8 +53,6 @@ MEMORY
 
 /* map generic regions to output sections */
 INCLUDE "alias.x"
-
-PROVIDE(__pre_init = ESP32PreInit); 
 
 /* esp32 specific regions */
 SECTIONS {

--- a/partitions.csv
+++ b/partitions.csv
@@ -1,3 +1,3 @@
 # Partition table
 # Name,   Type, SubType, Offset,  Size, Flags
-factory,  app,  factory, 0x10000, 1M,
+factory,  app,  factory, 0x10000, 0x3f0000,

--- a/partitions.csv
+++ b/partitions.csv
@@ -1,0 +1,3 @@
+# Partition table
+# Name,   Type, SubType, Offset,  Size, Flags
+factory,  app,  factory, 0x10000, 1M,

--- a/procmacros/Cargo.toml
+++ b/procmacros/Cargo.toml
@@ -16,7 +16,6 @@ proc-macro = true
 [dependencies]
 quote = "1.0"
 proc-macro2 = "1.0"
+darling = "0.10"
+syn = {version = "1.0", features = ["extra-traits", "full"]}
 
-[dependencies.syn]
-features = ["extra-traits", "full"]
-version = "1.0"

--- a/procmacros/Cargo.toml
+++ b/procmacros/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2018"
 [lib]
 proc-macro = true
 
+[features]
+external_ram=[]
+
 [dependencies]
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/procmacros/Cargo.toml
+++ b/procmacros/Cargo.toml
@@ -1,0 +1,22 @@
+  
+[package]
+authors = ["Arjan Mels <arjan@mels.email>"]
+categories = ["embedded", "no-std"]
+description = "Attributes re-exported in `esp32-hal`"
+keywords = ["esp32", "esp32-hal", "runtime", "startup"]
+license = "MIT OR Apache-2.0"
+name = "esp32-hal-proc-macros"
+repository = "https://github.com/esp-rs/xtensa-lx6-rt"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0"
+proc-macro2 = "1.0"
+
+[dependencies.syn]
+features = ["extra-traits", "full"]
+version = "1.0"

--- a/procmacros/src/lib.rs
+++ b/procmacros/src/lib.rs
@@ -128,6 +128,11 @@ pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
     match item {
         Item::Static(ref _struct_item) => section = quote! {#[link_section=#section_name_data]},
         Item::Fn(ref function_item) => {
+            if zeroed {
+                Span::call_site()
+                    .error("Zeroed is not applicable to functions")
+                    .emit();
+            }
             if uninitialized {
                 Span::call_site()
                     .error("Uninitialized is not applicable to functions")

--- a/procmacros/src/lib.rs
+++ b/procmacros/src/lib.rs
@@ -127,7 +127,6 @@ pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
     let section: proc_macro2::TokenStream;
     match item {
         Item::Static(ref _struct_item) => section = quote! {#[link_section=#section_name_data]},
-        Item::Const(ref _struct_item) => section = quote! {#[link_section=#section_name_data]},
         Item::Fn(ref function_item) => {
             if uninitialized {
                 Span::call_site()
@@ -149,7 +148,7 @@ pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
             section = quote! {};
             item.span()
                 .unstable()
-                .error("#[ram] attribute can only be applied to functions, statics and consts")
+                .error("#[ram] attribute can only be applied to functions and statics")
                 .emit();
         }
     }

--- a/procmacros/src/lib.rs
+++ b/procmacros/src/lib.rs
@@ -1,0 +1,154 @@
+//! Internal implementation details of `xtensa-lx6-rt`.
+//!
+//! Do not use this crate directly.
+
+#![deny(warnings)]
+#![feature(proc_macro_diagnostic)]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+//use proc_macro2::Span;
+use quote::quote;
+//use std::collections::HashSet;
+use syn::spanned::Spanned;
+use syn::Item;
+
+// check if all called function are in ram
+// check if all used data i in ram
+// check that no constants are use in teh function (these cannot be forced to ram)
+fn check_ram_function(func: &syn::ItemFn) {
+    eprintln!("{:?}", func);
+}
+
+#[proc_macro_attribute]
+pub fn ram(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let item: syn::Item = syn::parse(input).expect("failed to parse input");
+
+    let section: proc_macro2::TokenStream;
+    match item {
+        Item::Static(ref _struct_item) => section = quote! {#[link_section=".data"]},
+        Item::Const(ref _struct_item) => section = quote! {#[link_section=".data"]},
+        Item::Fn(ref function_item) => {
+            check_ram_function(function_item);
+            section = quote! {#[link_section=".rwtext"]};
+        }
+        _ => {
+            section = quote! {};
+            item.span()
+                .unstable()
+                .error("#[ram] attribute can only be applied to functions, statics and consts")
+                .emit();
+        }
+    }
+
+    let output = quote! {
+        #section
+        #item
+    };
+    output.into()
+
+    //    let f = parse_macro_input!(input as ItemFn);
+    /*    TokenStream::from(quote!(
+        #[link_section=".rwtext"]
+        #f
+    ))*/
+
+    /*
+        // check the function signature
+        let valid_signature = f.sig.constness.is_none()
+            && f.vis == Visibility::Inherited
+            && f.sig.abi.is_none()
+            && f.sig.inputs.is_empty()
+            && f.sig.generics.params.is_empty()
+            && f.sig.generics.where_clause.is_none()
+            && f.sig.variadic.is_none()
+            && match f.sig.output {
+                ReturnType::Default => false,
+                ReturnType::Type(_, ref ty) => match **ty {
+                    Type::Never(_) => true,
+                    _ => false,
+                },
+            };
+
+        if !valid_signature {
+            return parse::Error::new(
+                f.span(),
+                "`#[entry]` function must have signature `[unsafe] fn() -> !`",
+            )
+            .to_compile_error()
+            .into();
+        }
+
+        if !args.is_empty() {
+            return parse::Error::new(Span::call_site(), "This attribute accepts no arguments")
+                .to_compile_error()
+                .into();
+        }
+
+        // XXX should we blacklist other attributes?
+        let (statics, stmts) = match extract_static_muts(f.block.stmts) {
+            Err(e) => return e.to_compile_error().into(),
+            Ok(x) => x,
+        };
+
+        f.sig.ident = Ident::new(
+            &format!("__xtensa_lx6_rt_{}", f.sig.ident),
+            Span::call_site(),
+        );
+        f.sig.inputs.extend(statics.iter().map(|statik| {
+            let ident = &statik.ident;
+            let ty = &statik.ty;
+            let attrs = &statik.attrs;
+
+            // Note that we use an explicit `'static` lifetime for the entry point arguments. This makes
+            // it more flexible, and is sound here, since the entry will not be called again, ever.
+            syn::parse::<FnArg>(
+                quote!(#[allow(non_snake_case)] #(#attrs)* #ident: &'static mut #ty).into(),
+            )
+            .unwrap()
+        }));
+        f.block.stmts = stmts;
+
+        let tramp_ident = Ident::new(&format!("{}_trampoline", f.sig.ident), Span::call_site());
+        let ident = &f.sig.ident;
+
+        let resource_args = statics
+            .iter()
+            .map(|statik| {
+                let (ref cfgs, ref attrs) = extract_cfgs(statik.attrs.clone());
+                let ident = &statik.ident;
+                let ty = &statik.ty;
+                let expr = &statik.expr;
+                quote! {
+                    #(#cfgs)*
+                    {
+                        #(#attrs)*
+                        static mut #ident: #ty = #expr;
+                        &mut #ident
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if let Err(error) = check_attr_whitelist(&f.attrs, WhiteListCaller::Entry) {
+            return error;
+        }
+
+        let (ref cfgs, ref attrs) = extract_cfgs(f.attrs.clone());
+        quote!(
+            #(#cfgs)*
+            #(#attrs)*
+            #[doc(hidden)]
+            #[export_name = "main"]
+            pub unsafe extern "C" fn #tramp_ident() {
+                #ident(
+                    #(#resource_args),*
+                )
+            }
+
+            #f
+        )
+        .into()
+    */
+}

--- a/ram.x
+++ b/ram.x
@@ -1,0 +1,3 @@
+REGION_ALIAS("ROTEXT", iram_seg);
+REGION_ALIAS("RODATA", dram_seg);
+REGION_ALIAS("RWDATA", dram_seg);

--- a/rom.x
+++ b/rom.x
@@ -1,0 +1,3 @@
+REGION_ALIAS("ROTEXT", irom_seg);
+REGION_ALIAS("RODATA", drom_seg);
+REGION_ALIAS("RWDATA", dram_seg);

--- a/src/clock_control/mod.rs
+++ b/src/clock_control/mod.rs
@@ -37,8 +37,8 @@ pub mod watchdog;
 const DEFAULT_XTAL_FREQUENCY: Hertz = Hertz(40_000_000);
 
 // default frequencies for Dynamic Frequency Switching
-const CPU_SOURCE_DEFAULT_DEFAULT: CPUSource = CPUSource::Xtal;
-const CPU_FREQ_MIN_DEFAULT: Hertz = Hertz(10_000_000);
+const CPU_SOURCE_DEFAULT_DEFAULT: CPUSource = CPUSource::PLL;
+const CPU_FREQ_MIN_DEFAULT: Hertz = Hertz(80_000_000);
 const CPU_SOURCE_LOCKED_DEFAULT: CPUSource = CPUSource::PLL;
 const CPU_FREQ_MAX_DEFAULT: Hertz = Hertz(240_000_000);
 const CPU_SOURCE_APB_LOCKED_DEFAULT: CPUSource = CPUSource::PLL;

--- a/src/dprint.rs
+++ b/src/dprint.rs
@@ -44,10 +44,18 @@ pub static mut DEBUG_LOG: DebugLog = DebugLog {};
 #[macro_export]
 macro_rules! dprint {
     ($s:expr) => {
-        unsafe {$crate::dprint::DEBUG_LOG.write_str($s).unwrap()};
+        #[allow(unused_unsafe)]
+        unsafe {
+            use core::fmt::Write;
+            $crate::dprint::DEBUG_LOG.write_str($s).unwrap();
+        }
     };
     ($($arg:tt)*) => {
-        unsafe {$crate::dprint::DEBUG_LOG.write_fmt(format_args!($($arg)*)).unwrap()};
+        #[allow(unused_unsafe)]
+        unsafe {
+            use core::fmt::Write;
+            $crate::dprint::DEBUG_LOG.write_fmt(format_args!($($arg)*)).unwrap();
+        }
     };
 }
 
@@ -55,13 +63,25 @@ macro_rules! dprint {
 #[macro_export]
 macro_rules! dprintln {
     () => {
-        unsafe {$crate::dprint::DEBUG_LOG.write_str("\n").unwrap()};
+        #[allow(unused_unsafe)]
+        unsafe {
+            use core::fmt::Write;
+            $crate::dprint::DEBUG_LOG.write_str("\n").unwrap();
+        }
     };
     ($fmt:expr) => {
-        unsafe {$crate::dprint::DEBUG_LOG.write_str(concat!($fmt, "\n")).unwrap()};
+        #[allow(unused_unsafe)]
+        unsafe {
+            use core::fmt::Write;
+            $crate::dprint::DEBUG_LOG.write_str(concat!($fmt, "\n")).unwrap();
+        }
     };
     ($fmt:expr, $($arg:tt)*) => {
-        unsafe {$crate::dprint::DEBUG_LOG.write_fmt(format_args!(concat!($fmt, "\n"), $($arg)*)).unwrap()};
+        #[allow(unused_unsafe)]
+        unsafe {
+            use core::fmt::Write;
+            $crate::dprint::DEBUG_LOG.write_fmt(format_args!(concat!($fmt, "\n"), $($arg)*)).unwrap();
+        }
     };
 }
 
@@ -69,6 +89,9 @@ macro_rules! dprintln {
 #[macro_export]
 macro_rules! dflush {
     () => {
-        unsafe { while !$crate::dprint::DEBUG_LOG.is_idle() {} };
+        #[allow(unused_unsafe)]
+        unsafe {
+            while !$crate::dprint::DEBUG_LOG.is_idle() {}
+        }
     };
 }

--- a/src/dprint.rs
+++ b/src/dprint.rs
@@ -65,7 +65,7 @@ macro_rules! dprintln {
     };
 }
 
-/// Macro for sending a formatted string to UART0 for debugging, with a newline.
+/// Macro for flushing the UART0 TX buffer
 #[macro_export]
 macro_rules! dflush {
     () => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,15 @@
-//! This ESP32 hal  crate provides support for the ESP32 peripherals
+//! This ESP32 hal crate provides support for the ESP32 peripherals
 //!
 //! ## Features
 //! - `external_ram`
-//!     - Optional and experimental
 //!     - Enables support for external ram (psram). However proper initialization
-//!         for psram is not yet included
+//!         of external ram relies on a customized bootloader
+//! - `all_in_ram`
+//!     - Forces all code and data in RAM instead of flash. This allows usage with
+//!         the ROM bootloader and eases debugging
 
 #![no_std]
+#![feature(const_fn)]
 
 pub use embedded_hal as hal;
 pub use esp32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,48 +26,49 @@ pub mod units;
 #[macro_use]
 pub mod dprint;
 
-use xtensa_lx6_rt::{init_data, zero_bss};
-
-extern "C" {
-    // These symbols come from `memory.x`
-    static mut _rtc_fast_bss_start: u32;
-    static mut _rtc_fast_bss_end: u32;
-
-    static mut _rtc_slow_bss_start: u32;
-    static mut _rtc_slow_bss_end: u32;
-
-    static mut _external_bss_start: u32;
-    static mut _external_bss_end: u32;
-    static mut _external_data_start: u32;
-    static mut _external_data_end: u32;
-    static _external_data_load: u32;
-}
-
-/// Function initializes ESP32 specific memories (RTC slow and fast)
+/// Function initializes ESP32 specific memories (RTC slow and fast) and
+/// then calls original Reset function
 ///
-/// if #\[pre_init\] is used to override the pre-initialization this function must be called manually
-
-// function is used as default for __pre_init in memory.x
-// (Using #[pre_init] from library does not work properly)
+/// ENTRY point is defined in memory.x
+/// *Note: the pre_init function is called in the original reset handler
+/// after the initializations done in this function*
 #[doc(hidden)]
 #[no_mangle]
-pub unsafe extern "C" fn ESP32PreInit() {
+pub unsafe extern "C" fn ESP32Reset() -> ! {
+    // These symbols come from `memory.x`
+    extern "C" {
+        static mut _rtc_fast_bss_start: u32;
+        static mut _rtc_fast_bss_end: u32;
+
+        static mut _rtc_slow_bss_start: u32;
+        static mut _rtc_slow_bss_end: u32;
+
+        static mut _external_bss_start: u32;
+        static mut _external_bss_end: u32;
+        static mut _external_data_start: u32;
+        static mut _external_data_end: u32;
+        static _external_data_load: u32;
+    }
+
     // Initialize RTC RAM
-    zero_bss(&mut _rtc_fast_bss_start, &mut _rtc_fast_bss_end);
-    zero_bss(&mut _rtc_slow_bss_start, &mut _rtc_slow_bss_end);
+    xtensa_lx6_rt::zero_bss(&mut _rtc_fast_bss_start, &mut _rtc_fast_bss_end);
+    xtensa_lx6_rt::zero_bss(&mut _rtc_slow_bss_start, &mut _rtc_slow_bss_end);
 
     if cfg!(feature = "external_ram") {
-        zero_bss(&mut _external_bss_start, &mut _external_bss_end);
+        xtensa_lx6_rt::zero_bss(&mut _external_bss_start, &mut _external_bss_end);
 
         // external SRAM initialization not done by bootloader
         //
         // TODO: correct load address or memory map:
         // _external_data_load points to address when flash address 0 is mapped to 3f400000,
         // however after bootloader is finished this is no longer true
-        init_data(
+        xtensa_lx6_rt::init_data(
             &mut _external_data_start,
             &mut _external_data_end,
             &_external_data_load,
         );
     }
+
+    // continue with default reset handler
+    xtensa_lx6_rt::Reset();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,43 @@ pub mod units;
 
 #[macro_use]
 pub mod dprint;
+
+extern "C" {
+
+    // These symbols come from `memory.x`
+    static mut _rtc_fast_bss_start: u32;
+    static mut _rtc_fast_bss_end: u32;
+
+    static mut _rtc_fast_data_start: u32;
+    static mut _rtc_fast_data_end: u32;
+    static _rtc_fast_data_start_loadaddr: u32;
+
+    static mut _rtc_slow_bss_start: u32;
+    static mut _rtc_slow_bss_end: u32;
+
+    static mut _rtc_slow_data_start: u32;
+    static mut _rtc_slow_data_end: u32;
+    static _rtc_slow_data_start_loadaddr: u32;
+
+}
+
+//#[xtensa_lx6_rt::pre_init]
+
+#[xtensa_lx6_rt::pre_init]
+unsafe fn pre_init() {
+    loop {}
+    // Initialize RTC RAM
+    xtensa_lx6_rt::zero_bss(&mut _rtc_fast_bss_start, &mut _rtc_fast_bss_end);
+    xtensa_lx6_rt::init_data(
+        &mut _rtc_fast_data_start,
+        &mut _rtc_fast_data_end,
+        &_rtc_fast_data_start_loadaddr,
+    );
+
+    xtensa_lx6_rt::zero_bss(&mut _rtc_slow_bss_start, &mut _rtc_slow_bss_end);
+    xtensa_lx6_rt::init_data(
+        &mut _rtc_slow_data_start,
+        &mut _rtc_slow_data_end,
+        &_rtc_slow_data_start_loadaddr,
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,23 +50,15 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
         static _external_data_load: u32;
     }
 
+    // copying data from flash to various data segments is done by the bootloader
+    // initialization to zero needs to be done by the application
+
     // Initialize RTC RAM
     xtensa_lx6_rt::zero_bss(&mut _rtc_fast_bss_start, &mut _rtc_fast_bss_end);
     xtensa_lx6_rt::zero_bss(&mut _rtc_slow_bss_start, &mut _rtc_slow_bss_end);
 
     if cfg!(feature = "external_ram") {
         xtensa_lx6_rt::zero_bss(&mut _external_bss_start, &mut _external_bss_end);
-
-        // external SRAM initialization not done by bootloader
-        //
-        // TODO: correct load address or memory map:
-        // _external_data_load points to address when flash address 0 is mapped to 3f400000,
-        // however after bootloader is finished this is no longer true
-        xtensa_lx6_rt::init_data(
-            &mut _external_data_start,
-            &mut _external_data_end,
-            &_external_data_load,
-        );
     }
 
     // continue with default reset handler

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 pub use embedded_hal as hal;
 pub use esp32;
 
+extern crate esp32_hal_proc_macros as proc_macros;
+pub use proc_macros::ram;
+
 pub mod analog;
 pub mod clock_control;
 pub mod dport;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,3 +9,5 @@ pub use crate::gpio::GpioExt as _esp32_hal_gpio_GpioExt;
 pub use crate::units::*;
 
 pub use crate::proc_macros::*;
+
+pub use xtensa_lx6_rt::entry;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,3 +7,5 @@ pub use embedded_hal::prelude::*;
 pub use crate::analog::SensExt as _esp32_hal_analog_SensExt;
 pub use crate::gpio::GpioExt as _esp32_hal_gpio_GpioExt;
 pub use crate::units::*;
+
+pub use crate::proc_macros::*;


### PR DESCRIPTION
- Added ability to use flash/read-only code and data. (This requires usage of a 2nd stage bootloader)
- Updated flash script to be able to use bootloader
- Added support for RTC memories (and prepared support for external memory)
- Added #[ram] attribute to force placement of data in certain type of memory
- Added example to showcase #[ram] attribute

This builds on #11, which should be merged first. It also relies on a pull request of the xtensa-lx6-rt crate: https://github.com/esp-rs/xtensa-lx6-rt/pull/10 