### PR TITLE
Fix GPIO input configuration

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -297,15 +297,24 @@ impl_output! {
 }
 
 macro_rules! impl_pullup_pulldown {
-    ($en:ident, $pxi:ident, $i:expr, $funcXin:ident,
-        $iomux:ident, has_pullup_pulldown) => {
+    ($out_en_clear:ident, $pxi:ident, $pin_num:expr, $i:expr, $funcXout:ident, $funcXin:ident,
+        $sig_in_sel:ident, $func_in_sel:ident, $iomux:ident, has_pullup_pulldown) => {
         pub fn into_pull_up_input(self) -> $pxi<Input<PullUp>> {
             let gpio = unsafe{ &*GPIO::ptr() };
             let iomux = unsafe{ &*IO_MUX::ptr() };
             self.disable_analog();
 
-            gpio.$en.modify(|_, w| unsafe  { w.bits(0x1 << $i) });
-            gpio.$funcXin.modify(|_, w| unsafe { w.bits(0x100) });
+            gpio.$out_en_clear.modify(|_, w| unsafe { w.bits(0x1 << $i) });
+            gpio.$funcXout.modify(|_, w| unsafe { w.bits(0x100) });
+            gpio.$funcXin.modify(|_, w| unsafe {
+                w
+                    // route through GPIO matrix
+                    .$sig_in_sel()
+                    .set_bit()
+                    // use the GPIO pad
+                    .$func_in_sel()
+                    .bits($pin_num)
+            });
 
             iomux.$iomux.modify(|_, w| unsafe { w.mcu_sel().bits(0b10) });
             iomux.$iomux.modify(|_, w| w.fun_ie().set_bit());
@@ -319,8 +328,17 @@ macro_rules! impl_pullup_pulldown {
             let iomux = unsafe{ &*IO_MUX::ptr() };
             self.disable_analog();
 
-            gpio.$en.modify(|_, w| unsafe  { w.bits(0x1 << $i) });
-            gpio.$funcXin.modify(|_, w| unsafe { w.bits(0x100) });
+            gpio.$out_en_clear.modify(|_, w| unsafe  { w.bits(0x1 << $i) });
+            gpio.$funcXout.modify(|_, w| unsafe { w.bits(0x100) });
+            gpio.$funcXin.modify(|_, w| unsafe {
+                w
+                    // route through GPIO matrix
+                    .$sig_in_sel()
+                    .clear_bit()
+                    // use the GPIO pad
+                    .$func_in_sel()
+                    .bits($pin_num)
+            });
 
             iomux.$iomux.modify(|_, w| unsafe { w.mcu_sel().bits(0b10) });
             iomux.$iomux.modify(|_, w| w.fun_ie().set_bit());
@@ -329,21 +347,22 @@ macro_rules! impl_pullup_pulldown {
             $pxi { _mode: PhantomData }
         }
     };
-    ($en:ident, $pxi:ident, $i:expr, $funcXin:ident,
-        $iomux:ident, no_pullup_pulldown) => {
+    ($out_en_clear:ident, $pxi:ident, $pin_num:expr, $i:expr, $funcXout:ident, $funcXin:ident,
+        $sig_in_sel:ident, $func_in_sel:ident, $iomux:ident, no_pullup_pulldown) => {
         /* No pullup/pulldown resistor is available on this pin. */
     };
-    ($en:ident, $pxi:ident, $i:expr, $funcXin:ident,
-        $iomux:ident, $pullup_flag:ident) => {
+    ($out_en_clear:ident, $pxi:ident, $pin_num:expr, $i:expr, $funcXout:ident, $funcXin:ident,
+        $sig_in_sel:ident, $func_in_sel:ident, $iomux:ident, $pullup_flag:ident) => {
         compile_error! ("The GPIO pin has to be marked with either \
             has_pullup_pulldown or no_pullup_pulldown.");
     };
 }
 
 macro_rules! impl_input {
-    ($en:ident, $reg:ident, $reader:ident [
+    ($out_en_clear:ident, $reg:ident, $reader:ident [
         // index, gpio pin name, funcX name, iomux pin name, has pullup/down resistors
-        $($pxi:ident: ($i:expr, $pin:ident, $funcXin:ident, $iomux:ident, $resistors:ident),)+
+        $($pxi:ident: ($pin_num:expr, $i:expr, $pin:ident, $funcXout:ident, $funcXin:ident,
+            $sig_in_sel:ident, $func_in_sel:ident, $iomux:ident, $resistors:ident),)+
     ]) => {
         $(
             impl<MODE> InputPin for $pxi<Input<MODE>> {
@@ -364,8 +383,17 @@ macro_rules! impl_input {
                     let iomux = unsafe{ &*IO_MUX::ptr() };
                     self.disable_analog();
 
-                    gpio.$en.modify(|_, w| unsafe  { w.bits(0x1 << $i) });
-                    gpio.$funcXin.modify(|_, w| unsafe { w.bits(0x100) });
+                    gpio.$out_en_clear.modify(|_, w| unsafe { w.bits(0x1 << $i) });
+                    gpio.$funcXout.modify(|_, w| unsafe { w.bits(0x100) });
+                    gpio.$funcXin.modify(|_, w| unsafe {
+                        w
+                            // route through GPIO matrix
+                            .$sig_in_sel()
+                            .clear_bit()
+                            // use the GPIO pad
+                            .$func_in_sel()
+                            .bits($pin_num)
+                    });
 
                     iomux.$iomux.modify(|_, w| unsafe { w.mcu_sel().bits(0b10) });
                     iomux.$iomux.modify(|_, w| w.fun_ie().set_bit());
@@ -374,54 +402,55 @@ macro_rules! impl_input {
                     $pxi { _mode: PhantomData }
                 }
 
-                impl_pullup_pulldown! ($en, $pxi, $i, $funcXin, $iomux, $resistors);
+                impl_pullup_pulldown! ($out_en_clear, $pxi, $pin_num, $i, $funcXout, $funcXin,
+                    $sig_in_sel, $func_in_sel, $iomux, $resistors);
             }
         )+
     };
 }
 
 impl_input! {
-    enable_w1ts, in_, in_data [
-        Gpio0: (0, pin0, func0_in_sel_cfg, gpio0, has_pullup_pulldown),
-        Gpio1: (1, pin1, func1_in_sel_cfg, u0txd, has_pullup_pulldown),
-        Gpio2: (2, pin2, func2_in_sel_cfg, gpio2, has_pullup_pulldown),
-        Gpio3: (3, pin3, func3_in_sel_cfg, u0rxd, has_pullup_pulldown),
-        Gpio4: (4, pin4, func4_in_sel_cfg, gpio4, has_pullup_pulldown),
-        Gpio5: (5, pin5, func5_in_sel_cfg, gpio5, has_pullup_pulldown),
-        Gpio6: (6, pin6, func6_in_sel_cfg, sd_clk, has_pullup_pulldown),
-        Gpio7: (7, pin7, func7_in_sel_cfg, sd_data0, has_pullup_pulldown),
-        Gpio8: (8, pin8, func8_in_sel_cfg, sd_data1, has_pullup_pulldown),
-        Gpio9: (9, pin9, func9_in_sel_cfg, sd_data2, has_pullup_pulldown),
-        Gpio10: (10, pin10, func10_in_sel_cfg, sd_data3, has_pullup_pulldown),
-        Gpio11: (11, pin11, func11_in_sel_cfg, sd_cmd, has_pullup_pulldown),
-        Gpio12: (12, pin12, func12_in_sel_cfg, mtdi, has_pullup_pulldown),
-        Gpio13: (13, pin13, func13_in_sel_cfg, mtck, has_pullup_pulldown),
-        Gpio14: (14, pin14, func14_in_sel_cfg, mtms, has_pullup_pulldown),
-        Gpio15: (15, pin15, func15_in_sel_cfg, mtdo, has_pullup_pulldown),
-        Gpio16: (16, pin16, func16_in_sel_cfg, gpio16, has_pullup_pulldown),
-        Gpio17: (17, pin17, func17_in_sel_cfg, gpio17, has_pullup_pulldown),
-        Gpio18: (18, pin18, func18_in_sel_cfg, gpio18, has_pullup_pulldown),
-        Gpio19: (19, pin19, func19_in_sel_cfg, gpio19, has_pullup_pulldown),
-        Gpio20: (20, pin20, func20_in_sel_cfg, gpio20, has_pullup_pulldown),
-        Gpio21: (21, pin21, func21_in_sel_cfg, gpio21, has_pullup_pulldown),
-        Gpio22: (22, pin22, func22_in_sel_cfg, gpio22, has_pullup_pulldown),
-        Gpio23: (23, pin23, func23_in_sel_cfg, gpio23, has_pullup_pulldown),
-        Gpio25: (25, pin25, func25_in_sel_cfg, gpio25, has_pullup_pulldown),
-        Gpio26: (26, pin26, func26_in_sel_cfg, gpio26, has_pullup_pulldown),
-        Gpio27: (27, pin27, func27_in_sel_cfg, gpio27, has_pullup_pulldown),
+    enable_w1tc, in_, in_data [
+        Gpio0: (0, 0, pin0, func0_out_sel_cfg, func0_in_sel_cfg, sig0_in_sel, func0_in_sel, gpio0, has_pullup_pulldown),
+        Gpio1: (1, 1, pin1, func1_out_sel_cfg, func1_in_sel_cfg, sig1_in_sel, func1_in_sel, u0txd, has_pullup_pulldown),
+        Gpio2: (2, 2, pin2, func2_out_sel_cfg, func2_in_sel_cfg, sig2_in_sel, func2_in_sel, gpio2, has_pullup_pulldown),
+        Gpio3: (3, 3, pin3, func3_out_sel_cfg, func3_in_sel_cfg, sig3_in_sel, func3_in_sel, u0rxd, has_pullup_pulldown),
+        Gpio4: (4, 4, pin4, func4_out_sel_cfg, func4_in_sel_cfg, sig4_in_sel, func4_in_sel, gpio4, has_pullup_pulldown),
+        Gpio5: (5, 5, pin5, func5_out_sel_cfg, func5_in_sel_cfg, sig5_in_sel, func5_in_sel, gpio5, has_pullup_pulldown),
+        Gpio6: (6, 6, pin6, func6_out_sel_cfg, func6_in_sel_cfg, sig6_in_sel, func6_in_sel, sd_clk, has_pullup_pulldown),
+        Gpio7: (7, 7, pin7, func7_out_sel_cfg, func7_in_sel_cfg, sig7_in_sel, func7_in_sel, sd_data0, has_pullup_pulldown),
+        Gpio8: (8, 8, pin8, func8_out_sel_cfg, func8_in_sel_cfg, sig8_in_sel, func8_in_sel, sd_data1, has_pullup_pulldown),
+        Gpio9: (9, 9, pin9, func9_out_sel_cfg, func9_in_sel_cfg, sig9_in_sel, func9_in_sel, sd_data2, has_pullup_pulldown),
+        Gpio10: (10, 10, pin10, func10_out_sel_cfg, func10_in_sel_cfg, sig10_in_sel, func10_in_sel, sd_data3, has_pullup_pulldown),
+        Gpio11: (11, 11, pin11, func11_out_sel_cfg, func11_in_sel_cfg, sig11_in_sel, func11_in_sel, sd_cmd, has_pullup_pulldown),
+        Gpio12: (12, 12, pin12, func12_out_sel_cfg, func12_in_sel_cfg, sig12_in_sel, func12_in_sel, mtdi, has_pullup_pulldown),
+        Gpio13: (13, 13, pin13, func13_out_sel_cfg, func13_in_sel_cfg, sig13_in_sel, func13_in_sel, mtck, has_pullup_pulldown),
+        Gpio14: (14, 14, pin14, func14_out_sel_cfg, func14_in_sel_cfg, sig14_in_sel, func14_in_sel, mtms, has_pullup_pulldown),
+        Gpio15: (15, 15, pin15, func15_out_sel_cfg, func15_in_sel_cfg, sig15_in_sel, func15_in_sel, mtdo, has_pullup_pulldown),
+        Gpio16: (16, 16, pin16, func16_out_sel_cfg, func16_in_sel_cfg, sig16_in_sel, func16_in_sel, gpio16, has_pullup_pulldown),
+        Gpio17: (17, 17, pin17, func17_out_sel_cfg, func17_in_sel_cfg, sig17_in_sel, func17_in_sel, gpio17, has_pullup_pulldown),
+        Gpio18: (18, 18, pin18, func18_out_sel_cfg, func18_in_sel_cfg, sig18_in_sel, func18_in_sel, gpio18, has_pullup_pulldown),
+        Gpio19: (19, 19, pin19, func19_out_sel_cfg, func19_in_sel_cfg, sig19_in_sel, func19_in_sel, gpio19, has_pullup_pulldown),
+        Gpio20: (20, 20, pin20, func20_out_sel_cfg, func20_in_sel_cfg, sig20_in_sel, func20_in_sel, gpio20, has_pullup_pulldown),
+        Gpio21: (21, 21, pin21, func21_out_sel_cfg, func21_in_sel_cfg, sig21_in_sel, func21_in_sel, gpio21, has_pullup_pulldown),
+        Gpio22: (22, 22, pin22, func22_out_sel_cfg, func22_in_sel_cfg, sig22_in_sel, func22_in_sel, gpio22, has_pullup_pulldown),
+        Gpio23: (23, 23, pin23, func23_out_sel_cfg, func23_in_sel_cfg, sig23_in_sel, func23_in_sel, gpio23, has_pullup_pulldown),
+        Gpio25: (25, 25, pin25, func25_out_sel_cfg, func25_in_sel_cfg, sig25_in_sel, func25_in_sel, gpio25, has_pullup_pulldown),
+        Gpio26: (26, 26, pin26, func26_out_sel_cfg, func26_in_sel_cfg, sig26_in_sel, func26_in_sel, gpio26, has_pullup_pulldown),
+        Gpio27: (27, 27, pin27, func27_out_sel_cfg, func27_in_sel_cfg, sig27_in_sel, func27_in_sel, gpio27, has_pullup_pulldown),
     ]
 }
 
 impl_input! {
-    enable1_w1ts, in1, in1_data [
-        Gpio32: (0, pin32, func32_in_sel_cfg, gpio32, has_pullup_pulldown),
-        Gpio33: (1, pin33, func33_in_sel_cfg, gpio33, has_pullup_pulldown),
-        Gpio34: (2, pin34, func34_in_sel_cfg, gpio34, no_pullup_pulldown),
-        Gpio35: (3, pin35, func35_in_sel_cfg, gpio35, no_pullup_pulldown),
-        Gpio36: (4, pin36, func36_in_sel_cfg, gpio36, no_pullup_pulldown),
-        Gpio37: (5, pin37, func37_in_sel_cfg, gpio37, no_pullup_pulldown),
-        Gpio38: (6, pin38, func38_in_sel_cfg, gpio38, no_pullup_pulldown),
-        Gpio39: (7, pin39, func39_in_sel_cfg, gpio39, no_pullup_pulldown),
+    enable1_w1tc, in1, in1_data [
+        Gpio32: (32, 0, pin32, func32_out_sel_cfg, func32_in_sel_cfg, sig32_in_sel, func32_in_sel, gpio32, has_pullup_pulldown),
+        Gpio33: (33, 1, pin33, func33_out_sel_cfg, func33_in_sel_cfg, sig33_in_sel, func33_in_sel, gpio33, has_pullup_pulldown),
+        Gpio34: (34, 2, pin34, func34_out_sel_cfg, func34_in_sel_cfg, sig34_in_sel, func34_in_sel, gpio34, no_pullup_pulldown),
+        Gpio35: (35, 3, pin35, func35_out_sel_cfg, func35_in_sel_cfg, sig35_in_sel, func35_in_sel, gpio35, no_pullup_pulldown),
+        Gpio36: (36, 4, pin36, func36_out_sel_cfg, func36_in_sel_cfg, sig36_in_sel, func36_in_sel, gpio36, no_pullup_pulldown),
+        Gpio37: (37, 5, pin37, func37_out_sel_cfg, func37_in_sel_cfg, sig37_in_sel, func37_in_sel, gpio37, no_pullup_pulldown),
+        Gpio38: (38, 6, pin38, func38_out_sel_cfg, func38_in_sel_cfg, sig38_in_sel, func38_in_sel, gpio38, no_pullup_pulldown),
+        Gpio39: (39, 7, pin39, func39_out_sel_cfg, func39_in_sel_cfg, sig39_in_sel, func39_in_sel, gpio39, no_pullup_pulldown),
     ]
 }
 


### PR DESCRIPTION
* Most importantly, the output enable bit should be cleared rather than set.
* The output selector should be configured to use the output enable bit.
* The input selector is also configured.