### PR TITLE
Timer peripherals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ nb = "0.1.2"
 spin = "0.5.2"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
 linked_list_allocator = { version = "0.8.4", optional = true, default-features = false, features = ["alloc_ref"] }
+void = { version = "1.0.2", default-features = false }
 
 [dev-dependencies]
 panic-halt = "0.2.0"

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright 2019-2020 Contributors to xtensa-lx6-rt
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -57,8 +57,8 @@ fn main() -> ! {
         action4: WatchdogAction::DISABLE,
         period1: 2.s().into(),
         period2: 10.s().into(),
-        period3: 0.us(),
-        period4: 0.us(),
+        period3: 0.us().into(),
+        period4: 0.us().into(),
         cpu_reset_duration: WatchDogResetDuration::T800NS,
         sys_reset_duration: WatchDogResetDuration::T800NS,
         divider: 1,
@@ -82,7 +82,7 @@ fn main() -> ! {
 
     writeln!(tx, "\n\nESP32 Started\n\n").unwrap();
 
-    timer0.set_alarm(70_000_000);
+    timer0.set_alarm(70_000_000.into());
     timer0.enable_alarm(true);
     timer0.autoreload(true);
     timer0.enable_level_interrupt(true);

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -84,7 +84,7 @@ fn main() -> ! {
 
     timer0.set_alarm(70_000_000.into());
     timer0.enable_alarm(true);
-    timer0.autoreload(true);
+    timer0.auto_reload(true);
     timer0.enable_level_interrupt(true);
     timer0.enable_edge_interrupt(true);
 

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -56,7 +56,7 @@ fn main() -> ! {
         action3: WatchdogAction::DISABLE,
         action4: WatchdogAction::DISABLE,
         period1: 2.s().into(),
-        period2: 4.s().into(),
+        period2: 10.s().into(),
         period3: 0.us(),
         period4: 0.us(),
         cpu_reset_duration: WatchDogResetDuration::T800NS,
@@ -64,7 +64,7 @@ fn main() -> ! {
         divider: 1,
     };
 
-    watchdog1.set_config(&wdconfig);
+    watchdog1.set_config(&wdconfig).unwrap();
     //watchdog1.start(3.s());
 
     timer0.enable(true);

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -22,7 +22,7 @@ use spin::Mutex;
 const BLINK_HZ: Hertz = Hertz(2);
 
 static TIMER: Mutex<RefCell<Option<Timer<esp32::TIMG0, Timer0>>>> = Mutex::new(RefCell::new(None));
-static WATCHDOG1: Mutex<RefCell<Option<watchdog::WatchDog<esp32::TIMG1>>>> =
+static WATCHDOG1: Mutex<RefCell<Option<watchdog::Watchdog<esp32::TIMG1>>>> =
     Mutex::new(RefCell::new(None));
 
 #[no_mangle]

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(asm)]
 
 use core::fmt::Write;
 use core::panic::PanicInfo;

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -1,0 +1,154 @@
+#![no_std]
+#![no_main]
+#![feature(asm)]
+
+use core::fmt::Write;
+use core::panic::PanicInfo;
+
+use esp32_hal::prelude::*;
+
+use core::cell::RefCell;
+use core::ops::DerefMut;
+use esp32_hal::clock_control::sleep;
+use esp32_hal::dport::Split;
+use esp32_hal::dprintln;
+use esp32_hal::interrupt::{Interrupt, InterruptLevel};
+use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
+use esp32_hal::timer::{Timer, Timer0};
+use esp32_hal::Core::PRO;
+use spin::Mutex;
+
+const BLINK_HZ: Hertz = Hertz(2);
+
+static TIMER: Mutex<RefCell<Option<Timer<esp32::TIMG0, Timer0>>>> = Mutex::new(RefCell::new(None));
+
+#[no_mangle]
+fn main() -> ! {
+    let dp = esp32::Peripherals::take().unwrap();
+
+    let mut timg0 = dp.TIMG0;
+    let mut timg1 = dp.TIMG1;
+
+    disable_timg_wdts(&mut timg0, &mut timg1);
+
+    let (mut dport, dport_clock_control) = dp.DPORT.split();
+
+    let clkcntrl = esp32_hal::clock_control::ClockControl::new(
+        dp.RTCCNTL,
+        dp.APB_CTRL,
+        dport_clock_control,
+        esp32_hal::clock_control::XTAL_FREQUENCY_AUTO,
+    )
+    .unwrap();
+
+    let (clkcntrl_config, mut watchdog_rtc) = clkcntrl.freeze().unwrap();
+    let (mut timer0, mut timer1, mut watchdog0) = Timer::new(timg0, clkcntrl_config);
+    let (_, _, mut watchdog1) = Timer::new(timg1, clkcntrl_config);
+    watchdog_rtc.disable();
+    watchdog0.disable();
+    watchdog1.disable();
+
+    timer0.enable(true);
+    timer1.enable(true);
+
+    let config = Config {
+        baudrate: Hertz(115_200),
+        ..Default::default()
+    };
+
+    let serial =
+        Serial::uart0(dp.UART0, (NoTx, NoRx), config, clkcntrl_config, &mut dport).unwrap();
+
+    let (mut tx, _) = serial.split();
+
+    writeln!(tx, "\n\nESP32 Started\n\n").unwrap();
+
+    timer0.set_alarm(70_000_000);
+    timer0.enable_alarm(true);
+    timer0.autoreload(true);
+    timer0.enable_level_interrupt(true);
+    timer0.enable_edge_interrupt(true);
+
+    interrupt::free(|cs| {
+        timer0.listen(esp32_hal::timer::Event::TimeOut);
+        interrupt::enable_with_priority(PRO, Interrupt::TG0_T0_LEVEL_INTR, InterruptLevel(1))
+            .unwrap();
+        interrupt::enable_with_priority(PRO, Interrupt::TG0_T0_EDGE_INTR, InterruptLevel(1))
+            .unwrap();
+        *TIMER.lock().borrow_mut() = Some(timer0);
+    });
+
+    loop {
+        interrupt::free(|cs| {
+            if let Some(ref mut timer0) = TIMER.lock().borrow_mut().deref_mut() {
+                writeln!(
+                    tx,
+                    "Timers: {} {} {} {} {:x} {:x} {}",
+                    timer0.get_value(),
+                    timer0.alarm_active(),
+                    timer0.interrupt_active_raw(),
+                    timer0.interrupt_active(),
+                    interrupt::get_interrupt_status(PRO),
+                    xtensa_lx6_rt::interrupt::get(),
+                    timer1.get_value()
+                )
+                .unwrap();
+            }
+        });
+
+        sleep((Hertz(1_000_000) / BLINK_HZ).us());
+        sleep((Hertz(1_000_000) / BLINK_HZ).us());
+    }
+}
+
+#[interrupt]
+fn TG0_T0_LEVEL_INTR() {
+    interrupt::free(|cs| {
+        if let Some(ref mut timer0) = TIMER.lock().borrow_mut().deref_mut() {
+            timer0.clear_interrupt();
+            timer0.enable_alarm(true);
+        }
+    });
+    esp32_hal::dprintln!("  TG0_T0_LEVEL_INTR");
+}
+
+#[interrupt]
+fn TG0_T0_EDGE_INTR() {
+    interrupt::free(|cs| {
+        if let Some(ref mut timer0) = TIMER.lock().borrow_mut().deref_mut() {
+            esp32_hal::dprintln!("  TG0_T0_EDGE_INTR");
+
+            dprintln!(
+                "    Timers: {} {} {} {} {:x} {:x}",
+                timer0.get_value(),
+                timer0.alarm_active(),
+                timer0.interrupt_active_raw(),
+                timer0.interrupt_active(),
+                interrupt::get_interrupt_status(PRO),
+                xtensa_lx6_rt::interrupt::get(),
+            );
+            timer0.enable_alarm(true);
+        }
+    });
+}
+
+const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
+
+fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
+    timg0
+        .wdtwprotect
+        .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });
+    timg1
+        .wdtwprotect
+        .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });
+
+    timg0.wdtconfig0.write(|w| unsafe { w.bits(0x0) });
+    timg1.wdtconfig0.write(|w| unsafe { w.bits(0x0) });
+}
+
+/// Basic panic handler - just loops
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    dprintln!("\n\n*** {:?}", info);
+    loop {}
+}

--- a/flash
+++ b/flash
@@ -283,7 +283,7 @@ fi
 if [[ TERMINAL -eq 1 ]]
 then
     printf "\n${STAGE}Starting terminal.${RESET}\n"
-    gnome-terminal --geometry 200x15+0+2000 -- picocom -b $TERM_BAUDRATE $PORT --imap lfcrlf 2>/dev/null
+    gnome-terminal --geometry 200x15+0+9999 -- picocom -b $TERM_BAUDRATE $PORT --imap lfcrlf 2>/dev/null
 fi
 
 

--- a/procmacros/src/lib.rs
+++ b/procmacros/src/lib.rs
@@ -172,7 +172,9 @@ pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
 
 /// Marks a function as an interrupt handler
 ///
-/// When specified between braces that interrupt will be used and the function
+/// Used to handle on of the [interrupts](interrupt/enum.Interrupt.html).
+///
+/// When specified between braces (`#[interrupt(example)]`) that interrupt will be used and the function
 /// can have an arbitrary name. Otherwise the name of the function must be the name of the
 /// interrupt.
 #[proc_macro_attribute]

--- a/src/clock_control/mod.rs
+++ b/src/clock_control/mod.rs
@@ -500,13 +500,13 @@ impl ClockControl {
     }
 
     /// Freeze clock settings and return ClockControlConfig
-    pub fn freeze(self) -> Result<(ClockControlConfig, watchdog::WatchDog), Error> {
+    pub fn freeze(self) -> Result<(ClockControlConfig, watchdog::Watchdog), Error> {
         // can only occur one time as ClockControl is moved by this function and
         // the RTCCNTL and APBCTRL peripherals are moved when ClockControl is created
         unsafe { CLOCK_CONTROL = Some(self) };
 
         let res = ClockControlConfig {};
-        Ok((res, watchdog::WatchDog::new(res)))
+        Ok((res, watchdog::Watchdog::new(res)))
     }
 
     // TODO: check what dig_clk8m and dig_clk8m_256 are used for

--- a/src/clock_control/watchdog.rs
+++ b/src/clock_control/watchdog.rs
@@ -5,7 +5,7 @@
 //! - Consider add default configuration for start with time only
 
 use crate::prelude::*;
-use embedded_hal::watchdog::{Watchdog, WatchdogDisable, WatchdogEnable};
+use embedded_hal::watchdog::{WatchdogDisable, WatchdogEnable};
 use esp32::generic::Variant::Val;
 use esp32::rtccntl::wdtconfig0::*;
 use esp32::RTCCNTL;
@@ -17,7 +17,7 @@ const WATCHDOG_UNBLOCK_KEY: u32 = 0x50D83AA1;
 
 const WATCHDOG_BLOCK_VALUE: u32 = 0x89ABCDEF;
 
-pub struct WatchDog {
+pub struct Watchdog {
     clock_control_config: super::ClockControlConfig,
 }
 
@@ -55,10 +55,10 @@ pub struct WatchdogConfig {
     pub reset_cpu: (bool, bool),
 }
 
-impl WatchDog {
+impl Watchdog {
     /// internal function to create new watchdog structure
     pub(crate) fn new(clock_control_config: super::ClockControlConfig) -> Self {
-        WatchDog {
+        Watchdog {
             clock_control_config,
         }
     }
@@ -181,7 +181,7 @@ impl WatchDog {
 }
 
 /// Enable watchdog timer, only change stage 1 period, don't change default action
-impl WatchdogEnable for WatchDog {
+impl WatchdogEnable for Watchdog {
     type Time = MicroSeconds;
 
     fn start<T: Into<Self::Time>>(&mut self, period: T) {
@@ -207,7 +207,7 @@ impl WatchdogEnable for WatchDog {
 }
 
 /// Disable watchdog timer
-impl<'a> WatchdogDisable for WatchDog {
+impl<'a> WatchdogDisable for Watchdog {
     fn disable(&mut self) {
         self.access_registers(|rtc_control| {
             rtc_control.wdtfeed.write(|w| w.wdt_feed().set_bit());
@@ -219,7 +219,7 @@ impl<'a> WatchdogDisable for WatchDog {
 }
 
 /// Feed (=reset) the watchdog timer
-impl Watchdog for WatchDog {
+impl embedded_hal::watchdog::Watchdog for Watchdog {
     fn feed(&mut self) {
         self.access_registers(|rtc_control| {
             rtc_control.wdtfeed.write(|w| w.wdt_feed().set_bit());

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -109,7 +109,7 @@ fn interrupt_level_to_cpu_interrupt(
         None,                   // Level 2 edge triggered not supported
         Some(CPUInterrupt(22)), // Level 3 edge triggered
         Some(CPUInterrupt(28)), // Level 4 edge triggered
-        Some(CPUInterrupt(31)), // Level 5 edge triggered not supported
+        None,                   // Level 5 edge triggered not supported
         None,                   // Level 6 = Debug not supported for peripherals
         Some(CPUInterrupt(14)), // Level 7 = NMI edge triggered
     ];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod gpio;
 pub mod interrupt;
 pub mod prelude;
 pub mod serial;
+pub mod timer;
 pub mod units;
 
 #[cfg(feature = "alloc")]

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -57,6 +57,13 @@ pub struct Timer1 {}
 impl TimerInst for Timer1 {}
 
 impl<TIMG: TimerGroup> Timer<TIMG, Timer0> {
+    /// Create new timer resources
+    ///
+    /// This function will create 2 timers and 1 watchdog for a timer group.
+    /// It uses the clock_control_config for obtaining the clock configuration.
+    ///
+    /// *Note: time to clock tick conversions are done with the clock frequency when the
+    /// [start](embedded_hal::timer::CountDown::start) function is called. The clock frequency is not locked.*
     pub fn new(
         timg: TIMG,
         clock_control_config: ClockControlConfig,
@@ -87,12 +94,16 @@ impl<TIMG: TimerGroup> Timer<TIMG, Timer0> {
 }
 
 impl<INST: TimerInst> Timer<TIMG0, INST> {
+    /// Releases the timer resources. Requires to release all timers and watchdog belonging to
+    /// the same group at once.
     pub fn release(_timer0: Timer<TIMG0, Timer0>, _timer1: Timer<TIMG0, Timer1>) -> TIMG0 {
         unsafe { esp32::Peripherals::steal().TIMG0 }
     }
 }
 
 impl<INST: TimerInst> Timer<TIMG1, INST> {
+    /// Releases the timer resources. Requires to release all timers and watchdog belonging to
+    /// the same group at once.
     pub fn release(_timer0: Timer<TIMG1, Timer0>, _timer1: Timer<TIMG1, Timer1>) -> TIMG1 {
         unsafe { esp32::Peripherals::steal().TIMG1 }
     }

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -100,7 +100,7 @@ static TIMER_MUTEX: spin::Mutex<()> = spin::Mutex::new(());
 macro_rules! timer {
     ($TIMX:ident, $INT_ENA:ident, $CONFIG:ident, $HI:ident, $LO: ident,
         $LOAD: ident, $LOAD_HI: ident, $LOAD_LO:ident, $UPDATE:ident, $ALARM_HI:ident,
-        $ALARM_LO:ident, $EN:ident, $INCREASE:ident, $AUTORE_LOAD:ident, $DIVIDER:ident,
+        $ALARM_LO:ident, $EN:ident, $INCREASE:ident, $AUTO_RELOAD:ident, $DIVIDER:ident,
         $EDGE_INT_EN:ident, $LEVEL_INT_EN:ident, $ALARM_EN:ident,
         $INT_RAW:ident, $INT_ST:ident, $INT_CLR:ident
     ) => {
@@ -190,11 +190,11 @@ macro_rules! timer {
                 }
             }
 
-            pub fn autoreload(&mut self, enable: bool) {
+            pub fn auto_reload(&mut self, enable: bool) {
                 unsafe {
                     (*(self.timg))
                         .$CONFIG
-                        .modify(|_, w| w.$AUTORE_LOAD().bit(enable))
+                        .modify(|_, w| w.$AUTO_RELOAD().bit(enable))
                 }
             }
 

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -1,0 +1,311 @@
+//! Integrated timer control
+//!
+//!
+//!
+//!
+//!
+
+use embedded_hal::timer::{CountDown, Periodic};
+
+use crate::clock_control::ClockControlConfig;
+use crate::prelude::*;
+use core::marker::PhantomData;
+use esp32::{TIMG0, TIMG1};
+
+pub mod watchdog;
+
+/// Timer errors
+#[derive(Debug)]
+pub enum Error {
+    /// Unsupported frequency configuration
+    UnsupportedWatchdogConfig,
+}
+
+/// Hardware timers
+pub struct Timer<TIMG, INST> {
+    clock_control: ClockControlConfig,
+    timg: *const esp32::timg::RegisterBlock,
+    _group: PhantomData<TIMG>,
+    _timer: PhantomData<INST>,
+}
+
+unsafe impl<TIMG, INST> Send for Timer<TIMG, INST> {}
+
+/// Interrupt events
+pub enum Event {
+    /// Timer timed out / count down ended
+    TimeOut,
+}
+
+pub trait TimerGroup: core::ops::Deref {}
+impl TimerGroup for esp32::TIMG0 {}
+impl TimerGroup for esp32::TIMG1 {}
+
+pub trait TimerInst {}
+
+pub struct TimerX {}
+impl TimerInst for TimerX {}
+pub struct Timer0 {}
+impl TimerInst for Timer0 {}
+pub struct Timer1 {}
+impl TimerInst for Timer1 {}
+
+impl<TIMG> Timer<TIMG, TimerX>
+where
+    TIMG: TimerGroup,
+{
+    pub fn new(
+        timg: TIMG,
+        clock_control: ClockControlConfig,
+    ) -> (
+        Timer<TIMG, Timer0>,
+        Timer<TIMG, Timer1>,
+        watchdog::WatchDog<TIMG>,
+    ) {
+        let timer0 = Timer::<TIMG, Timer0> {
+            clock_control,
+            timg: &*timg as *const _ as *const esp32::timg::RegisterBlock,
+            _group: PhantomData {},
+            _timer: PhantomData {},
+        };
+        let timer1 = Timer::<TIMG, Timer1> {
+            clock_control,
+            timg: &*timg as *const _ as *const esp32::timg::RegisterBlock,
+            _group: PhantomData {},
+            _timer: PhantomData {},
+        };
+        (timer0, timer1, watchdog::WatchDog::new(timg, clock_control))
+    }
+}
+
+impl<INST> Timer<TIMG0, INST>
+where
+    INST: TimerInst,
+{
+    pub fn release(_timer0: Timer<TIMG0, Timer0>, _timer1: Timer<TIMG0, Timer1>) -> TIMG0 {
+        unsafe { esp32::Peripherals::steal().TIMG0 }
+    }
+}
+
+impl<INST> Timer<TIMG1, INST>
+where
+    INST: TimerInst,
+{
+    pub fn release(_timer0: Timer<TIMG1, Timer0>, _timer1: Timer<TIMG1, Timer1>) -> TIMG1 {
+        unsafe { esp32::Peripherals::steal().TIMG1 }
+    }
+}
+
+static TIMER_MUTEX: spin::Mutex<()> = spin::Mutex::new(());
+
+macro_rules! timer {
+    ($TIMX:ident, $INT_ENA:ident, $CONFIG:ident, $HI:ident, $LO: ident,
+        $LOAD: ident, $LOADHI: ident, $LOADLO:ident, $UPDATE:ident, $ALARMHI:ident,
+        $ALARMLO:ident, $EN:ident, $INCREASE:ident, $AUTORELOAD:ident, $DIVIDER:ident,
+        $EDGE_INT_EN:ident, $LEVEL_INT_EN:ident, $ALARM_EN:ident,
+        $INT_RAW:ident, $INT_ST:ident, $INT_CLR:ident
+    ) => {
+        impl<TIMG> Timer<TIMG, $TIMX>
+        where
+            TIMG: TimerGroup,
+        {
+            /// Starts listening for an `event`
+            //  Needs multi-threaded protection as timer0 and 1 use same register
+            pub fn listen(&mut self, event: Event) {
+                match event {
+                    Event::TimeOut => unsafe {
+                        interrupt::free(|_| {
+                            TIMER_MUTEX.lock();
+                            (*(self.timg))
+                                .int_ena_timers
+                                .modify(|_, w| w.$INT_ENA().set_bit());
+                        });
+                    },
+                }
+            }
+
+            /// Stops listening for an `event`
+            //  Needs multi-threaded protection as timer0 and 1 use same register
+            pub fn unlisten(&mut self, event: Event) {
+                match event {
+                    Event::TimeOut => unsafe {
+                        interrupt::free(|_| {
+                            TIMER_MUTEX.lock();
+                            (*(self.timg))
+                                .int_ena_timers
+                                .modify(|_, w| w.$INT_ENA().clear_bit())
+                        });
+                    },
+                }
+            }
+
+            pub fn set_value(&mut self, value: u64) {
+                unsafe {
+                    (*(self.timg)).$LOADLO.write(|w| w.bits(value as u32));
+                    (*(self.timg))
+                        .$LOADHI
+                        .write(|w| w.bits((value >> 32) as u32));
+                    (*(self.timg)).$LOAD.write(|w| w.bits(1));
+                }
+            }
+
+            pub fn get_value(&mut self) -> u64 {
+                unsafe {
+                    (*(self.timg)).$UPDATE.write(|w| w.bits(1));
+                    (((*(self.timg)).$HI.read().bits() as u64) << 32)
+                        | ((*(self.timg)).$LO.read().bits() as u64)
+                }
+            }
+
+            pub fn get_alarm(&mut self) -> u64 {
+                unsafe {
+                    (((*(self.timg)).$ALARMHI.read().bits() as u64) << 32)
+                        | ((*(self.timg)).$ALARMLO.read().bits() as u64)
+                }
+            }
+
+            pub fn set_alarm(&mut self, value: u64) {
+                unsafe {
+                    // TODO: surround by disable and enable to prevent false trigger
+                    (*(self.timg)).$ALARMLO.write(|w| w.bits(value as u32));
+                    (*(self.timg))
+                        .$ALARMHI
+                        .write(|w| w.bits((value >> 32) as u32));
+                }
+            }
+
+            pub fn enable(&mut self, enable: bool) {
+                unsafe { (*(self.timg)).$CONFIG.modify(|_, w| w.$EN().bit(enable)) }
+            }
+
+            pub fn increasing(&mut self, enable: bool) {
+                unsafe {
+                    (*(self.timg))
+                        .$CONFIG
+                        .modify(|_, w| w.$INCREASE().bit(enable))
+                }
+            }
+
+            pub fn autoreload(&mut self, enable: bool) {
+                unsafe {
+                    (*(self.timg))
+                        .$CONFIG
+                        .modify(|_, w| w.$AUTORELOAD().bit(enable))
+                }
+            }
+
+            pub fn enable_edge_interrupt(&mut self, enable: bool) {
+                unsafe {
+                    (*(self.timg))
+                        .$CONFIG
+                        .modify(|_, w| w.$EDGE_INT_EN().bit(enable))
+                }
+            }
+
+            pub fn enable_level_interrupt(&mut self, enable: bool) {
+                unsafe {
+                    (*(self.timg))
+                        .$CONFIG
+                        .modify(|_, w| w.$LEVEL_INT_EN().bit(enable))
+                }
+            }
+
+            pub fn enable_alarm(&mut self, enable: bool) {
+                unsafe {
+                    (*(self.timg))
+                        .$CONFIG
+                        .modify(|_, w| w.$ALARM_EN().bit(enable))
+                }
+            }
+
+            pub fn alarm_active(&mut self) -> bool {
+                unsafe { (*(self.timg)).$CONFIG.read().$ALARM_EN().bit_is_set() }
+            }
+
+            pub fn interrupt_active_raw(&mut self) -> bool {
+                unsafe { (*(self.timg)).int_raw_timers.read().$INT_RAW().bit_is_set() }
+            }
+
+            pub fn interrupt_active(&mut self) -> bool {
+                unsafe { (*(self.timg)).int_st_timers.read().$INT_ST().bit_is_set() }
+            }
+
+            pub fn clear_interrupt(&mut self) {
+                unsafe {
+                    (*(self.timg))
+                        .int_clr_timers
+                        .write(|w| w.$INT_CLR().set_bit())
+                }
+            }
+        }
+    };
+}
+
+timer!(
+    Timer0,
+    t0_int_ena,
+    t0config,
+    t0hi,
+    t0lo,
+    t0load,
+    t0loadhi,
+    t0loadlo,
+    t0update,
+    t0alarmhi,
+    t0alarmlo,
+    t0_en,
+    t0_increase,
+    t0_autoreload,
+    t0_divider,
+    t0_edge_int_en,
+    t0_level_int_en,
+    t0_alarm_en,
+    t0_int_raw,
+    t0_int_st,
+    t0_int_clr
+);
+
+timer!(
+    Timer1,
+    t1_int_ena,
+    t1config,
+    t1hi,
+    t1lo,
+    t1load,
+    t1loadhi,
+    t1loadlo,
+    t1update,
+    t1alarmhi,
+    t1alarmlo,
+    t1_en,
+    t1_increase,
+    t1_autoreload,
+    t1_divider,
+    t1_edge_int_en,
+    t1_level_int_en,
+    t1_alarm_en,
+    t1_int_raw,
+    t1_int_st,
+    t1_int_clr
+);
+
+/*
+impl Timer<esp32::TIMG0> {
+    pub fn timer0(
+        _timg: esp32::TIMG0,
+        clock_control: ClockControlConfig,
+    ) -> (Self, Self, watchdog::WatchDog) {
+        let timer0 = Timer::<esp32::TIMG0> {
+            clock_control,
+            timg: TIMG0::ptr(),
+            _group: PhantomData {},
+        };
+        let timer1 = Timer::<esp32::TIMG0> {
+            clock_control,
+            timg: TIMG0::ptr(),
+            _group: PhantomData {},
+        };
+        (timer0, timer1, watchdog::WatchDog::new(clock_control))
+    }
+}
+*/

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -1,8 +1,12 @@
-//! Integrated timer control
+//! Timer peripherals
 //!
+//! ESP32 supports two timer groups, with each timer group supports 3 timers
+//! (Timer 0, 1 and Timer Lact) and a watchdog.
+//! The timers are 64 bits and run from the APB clock divided by a programmable factor.
 //!
-//!
-//!
+//! # TODO
+//! - Implement processor counter (CCOMPARE)
+//! - Implement FRC1 & FRC2 counters
 //!
 
 use embedded_hal::timer::{Cancel, CountDown, Periodic};
@@ -26,6 +30,12 @@ pub enum Error {
 }
 
 /// Hardware timers
+///
+/// The timers can be programmed in a high level way via
+/// [start](embedded_hal::timer::CountDown::start), [wait](embedded_hal::timer::CountDown::wait),
+/// [cancel](embedded_hal::timer::Cancel::cancel).
+///
+/// Lower level access is provided by the other functions.
 pub struct Timer<TIMG: TimerGroup, INST: TimerInst> {
     clock_control_config: ClockControlConfig,
     timg: *const esp32::timg::RegisterBlock,

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -19,6 +19,7 @@ pub mod watchdog;
 pub enum Error {
     /// Unsupported frequency configuration
     UnsupportedWatchdogConfig,
+    OutOfRange,
 }
 
 /// Hardware timers

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -60,7 +60,7 @@ impl<TIMG: TimerGroup> Timer<TIMG, Timer0> {
     ) -> (
         Timer<TIMG, Timer0>,
         Timer<TIMG, Timer1>,
-        watchdog::WatchDog<TIMG>,
+        watchdog::Watchdog<TIMG>,
     ) {
         let timer0 = Timer::<TIMG, Timer0> {
             clock_control,
@@ -74,7 +74,7 @@ impl<TIMG: TimerGroup> Timer<TIMG, Timer0> {
             _group: PhantomData {},
             _timer: PhantomData {},
         };
-        (timer0, timer1, watchdog::WatchDog::new(timg, clock_control))
+        (timer0, timer1, watchdog::Watchdog::new(timg, clock_control))
     }
 }
 
@@ -285,7 +285,7 @@ impl Timer<esp32::TIMG0> {
     pub fn timer0(
         _timg: esp32::TIMG0,
         clock_control: ClockControlConfig,
-    ) -> (Self, Self, watchdog::WatchDog) {
+    ) -> (Self, Self, watchdog::Watchdog) {
         let timer0 = Timer::<esp32::TIMG0> {
             clock_control,
             timg: TIMG0::ptr(),
@@ -296,7 +296,7 @@ impl Timer<esp32::TIMG0> {
             timg: TIMG0::ptr(),
             _group: PhantomData {},
         };
-        (timer0, timer1, watchdog::WatchDog::new(clock_control))
+        (timer0, timer1, watchdog::Watchdog::new(clock_control))
     }
 }
 */

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -19,6 +19,7 @@ pub mod watchdog;
 pub enum Error {
     /// Unsupported frequency configuration
     UnsupportedWatchdogConfig,
+    /// Value out of range
     OutOfRange,
 }
 

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -137,7 +137,7 @@ macro_rules! timer {
 
             pub fn set_value<T: Into<TicksU64>>(&mut self, value: T) {
                 unsafe {
-                    let timg = *(self.timg);
+                    let timg = &*(self.timg);
                     let value: u64 = value.into().into();
                     timg.$LOAD_LO.write(|w| w.bits(value as u32));
                     timg.$LOAD_HI.write(|w| w.bits((value >> 32) as u32));
@@ -147,7 +147,7 @@ macro_rules! timer {
 
             pub fn get_value(&mut self) -> TicksU64 {
                 unsafe {
-                    let timg = *(self.timg);
+                    let timg = &*(self.timg);
                     timg.$UPDATE.write(|w| w.bits(1));
                     TicksU64(
                         ((timg.$HI.read().bits() as u64) << 32) | (timg.$LO.read().bits() as u64),
@@ -157,7 +157,7 @@ macro_rules! timer {
 
             pub fn get_alarm(&mut self) -> TicksU64 {
                 unsafe {
-                    let timg = *(self.timg);
+                    let timg = &*(self.timg);
                     TicksU64(
                         ((timg.$ALARM_HI.read().bits() as u64) << 32)
                             | (timg.$ALARM_LO.read().bits() as u64),
@@ -171,7 +171,7 @@ macro_rules! timer {
             /// setting upper and lower 32 bits.*
             pub fn set_alarm(&mut self, value: TicksU64) {
                 unsafe {
-                    let timg = *(self.timg);
+                    let timg = &*(self.timg);
                     let value: u64 = value.into();
                     timg.$ALARM_HI.write(|w| w.bits((value >> 32) as u32));
                     timg.$ALARM_LO.write(|w| w.bits(value as u32));

--- a/src/timer/watchdog.rs
+++ b/src/timer/watchdog.rs
@@ -199,6 +199,14 @@ where
             });
         });
     }
+
+    pub fn clear_interrupt(&mut self) {
+        unsafe {
+            (*(self.timg))
+                .int_clr_timers
+                .write(|w| w.wdt_int_clr().set_bit());
+        }
+    }
 }
 
 /// Enable watchdog timer, only change stage 1 period, don't change default action

--- a/src/timer/watchdog.rs
+++ b/src/timer/watchdog.rs
@@ -106,7 +106,9 @@ impl<TIMG: TimerGroup> Watchdog<TIMG> {
         divider: u16,
     ) -> Result<u32, core::num::TryFromIntError> {
         use core::convert::TryFrom;
-        u32::try_from(self.clock_control_config.apb_frequency() / u32::from(divider) * value.into())
+        let freq = self.clock_control_config.apb_frequency() / u32::from(divider);
+        let ticks = freq * value.into();
+        u32::try_from(ticks)
     }
 
     /// Calculate ticks from period

--- a/src/timer/watchdog.rs
+++ b/src/timer/watchdog.rs
@@ -1,0 +1,221 @@
+//! RTC Watchdog implementation
+//!
+//! # TODO:
+//! - Add convenience methods for configuration
+//! - Consider add default configuration for start with time only
+
+use super::TimerGroup;
+use crate::prelude::*;
+use core::marker::PhantomData;
+use embedded_hal::watchdog::{Watchdog, WatchdogDisable, WatchdogEnable};
+use esp32::timg::wdtconfig0::*;
+
+pub type WatchdogAction = WDT_STG0_A;
+pub type WatchDogResetDuration = WDT_CPU_RESET_LENGTH_A;
+
+const WATCHDOG_UNBLOCK_KEY: u32 = 0x50D83AA1;
+const WATCHDOG_BLOCK_VALUE: u32 = 0x89ABCDEF;
+
+pub struct WatchDog<TIMG>
+where
+    TIMG: TimerGroup,
+{
+    clock_control_config: super::ClockControlConfig,
+    timg: *const esp32::timg::RegisterBlock,
+    _group: PhantomData<TIMG>,
+}
+
+/// Watchdog configuration
+///
+/// The watchdog has four stages.
+/// Each of these stages can take a configurable action after expiry of the corresponding period.
+/// When this action is done, it will move to the next stage.
+/// The stage is reset to the first when the watchdog timer is fed.
+#[derive(Debug)]
+pub struct WatchdogConfig {
+    // Delay before the first action to be taken
+    pub period1: MicroSeconds,
+    // First action
+    pub action1: WatchdogAction,
+    // Delay before the second action to be taken
+    pub period2: MicroSeconds,
+    // Second action
+    pub action2: WatchdogAction,
+    // Delay before the third action to be taken
+    pub period3: MicroSeconds,
+    // Third action
+    pub action3: WatchdogAction,
+    // Delay before the fourth action to be taken
+    pub period4: MicroSeconds,
+    // Fourth action
+    pub action4: WatchdogAction,
+    /// Duration of the cpu reset signal
+    pub cpu_reset_duration: WatchDogResetDuration,
+    /// Duration of the system reset signal
+    pub sys_reset_duration: WatchDogResetDuration,
+    /// Clock pre-scaling divider
+    pub divider: u16,
+}
+
+impl<TIMG> WatchDog<TIMG>
+where
+    TIMG: TimerGroup,
+{
+    /// internal function to create new watchdog structure
+    pub(crate) fn new(timg: TIMG, clock_control_config: super::ClockControlConfig) -> Self {
+        WatchDog {
+            clock_control_config,
+            timg: &*timg as *const _ as *const esp32::timg::RegisterBlock,
+            _group: PhantomData,
+        }
+    }
+
+    /// function to unlock the watchdog (write unblock key) and lock after use
+    fn access_registers<A, F: FnMut(&esp32::timg::RegisterBlock) -> A>(&mut self, mut f: F) -> A {
+        // Unprotect write access to registers
+
+        let timg = unsafe { &*(self.timg) };
+
+        timg.wdtwprotect
+            .write(|w| unsafe { w.bits(WATCHDOG_UNBLOCK_KEY) });
+
+        let a = f(&timg);
+
+        // Protect again
+        timg.wdtwprotect
+            .write(|w| unsafe { w.bits(WATCHDOG_BLOCK_VALUE) });
+
+        a
+    }
+
+    /// Calculate period from ticks
+    fn calc_period(&self, value: u32) -> MicroSeconds {
+        ((1_000_000u64 * value as u64 / u32::from(self.clock_control_config.apb_frequency()) as u64)
+            as u32)
+            .us()
+    }
+
+    /// Calculate ticks from period
+    fn calc_ticks(&self, value: MicroSeconds) -> u32 {
+        ((u32::from(value) as u64 * u32::from(self.clock_control_config.apb_frequency()) as u64)
+            / 1_000_000u64) as u32
+    }
+
+    /// Get watchdog configuration
+    pub fn config(&self) -> Result<WatchdogConfig, super::Error> {
+        let timg = unsafe { &*(self.timg) };
+        let wdtconfig0 = timg.wdtconfig0.read();
+
+        let stg0 = wdtconfig0.wdt_stg0().variant();
+        let stg1 = wdtconfig0.wdt_stg1().variant();
+        let stg2 = wdtconfig0.wdt_stg2().variant();
+        let stg3 = wdtconfig0.wdt_stg3().variant();
+
+        Ok(WatchdogConfig {
+            period1: self.calc_period(timg.wdtconfig2.read().bits()),
+            action1: stg0,
+            period2: self.calc_period(timg.wdtconfig3.read().bits()),
+            action2: stg1,
+            period3: self.calc_period(timg.wdtconfig4.read().bits()),
+            action3: stg2,
+            period4: self.calc_period(timg.wdtconfig5.read().bits()),
+            action4: stg3,
+            cpu_reset_duration: wdtconfig0.wdt_cpu_reset_length().variant(),
+            sys_reset_duration: wdtconfig0.wdt_sys_reset_length().variant(),
+            divider: timg.wdtconfig1.read().wdt_clk_prescale().bits(),
+        })
+    }
+
+    /// Change watchdog timer configuration and start
+    pub fn set_config(&mut self, config: &WatchdogConfig) {
+        let per1 = self.calc_ticks(config.period1.into());
+        let per2 = self.calc_ticks(config.period2.into());
+        let per3 = self.calc_ticks(config.period3.into());
+        let per4 = self.calc_ticks(config.period4.into());
+
+        self.access_registers(|timg| {
+            unsafe { timg.wdtfeed.write(|w| w.wdt_feed().bits(0)) }
+            timg.wdtconfig0.modify(|_, w| {
+                w.wdt_stg0()
+                    .variant(config.action1)
+                    .wdt_stg1()
+                    .variant(config.action2)
+                    .wdt_stg2()
+                    .variant(config.action3)
+                    .wdt_stg3()
+                    .variant(config.action4)
+                    .wdt_en()
+                    .set_bit()
+                    .wdt_edge_int_en()
+                    .set_bit()
+                    .wdt_level_int_en()
+                    .set_bit()
+                    .wdt_flashboot_mod_en()
+                    .clear_bit()
+                    .wdt_cpu_reset_length()
+                    .variant(config.cpu_reset_duration)
+                    .wdt_sys_reset_length()
+                    .variant(config.sys_reset_duration)
+            });
+            timg.wdtconfig1
+                .write(|w| unsafe { w.wdt_clk_prescale().bits(config.divider) });
+            timg.wdtconfig2.write(|w| unsafe { w.bits(per1) });
+            timg.wdtconfig3.write(|w| unsafe { w.bits(per2) });
+            timg.wdtconfig4.write(|w| unsafe { w.bits(per3) });
+            timg.wdtconfig5.write(|w| unsafe { w.bits(per4) });
+        });
+    }
+}
+
+/// Enable watchdog timer, only change stage 1 period, don't change default action
+impl<TIMG> WatchdogEnable for WatchDog<TIMG>
+where
+    TIMG: TimerGroup,
+{
+    type Time = MicroSeconds;
+
+    fn start<T: Into<Self::Time>>(&mut self, period: T) {
+        let per = self.calc_ticks(period.into());
+
+        self.access_registers(|timg| {
+            unsafe { timg.wdtfeed.write(|w| w.wdt_feed().bits(0)) }
+            timg.wdtconfig2.write(|w| unsafe { w.bits(per) });
+            timg.wdtconfig1
+                .write(|w| unsafe { w.wdt_clk_prescale().bits(1) });
+            timg.wdtconfig0.modify(|_, w| {
+                w.wdt_flashboot_mod_en()
+                    .clear_bit()
+                    .wdt_en()
+                    .set_bit()
+                    .wdt_stg0()
+                    .variant(WatchdogAction::RESETSYSTEM)
+            });
+        });
+    }
+}
+
+/// Disable watchdog timer
+//#[allow(trivial_bounds)]
+impl<'a, TIMG> WatchdogDisable for WatchDog<TIMG>
+where
+    TIMG: TimerGroup,
+{
+    fn disable(&mut self) {
+        self.access_registers(|timg| {
+            unsafe { timg.wdtfeed.write(|w| w.wdt_feed().bits(0)) }
+            timg.wdtconfig0
+                .modify(|_, w| w.wdt_flashboot_mod_en().clear_bit().wdt_en().clear_bit());
+        });
+    }
+}
+
+/// Feed (=reset) the watchdog timer
+#[allow(trivial_bounds)]
+impl<TIMG> Watchdog for WatchDog<TIMG>
+where
+    TIMG: TimerGroup,
+{
+    fn feed(&mut self) {
+        self.access_registers(|timg| unsafe { timg.wdtfeed.write(|w| w.wdt_feed().bits(0)) });
+    }
+}

--- a/src/units.rs
+++ b/src/units.rs
@@ -15,22 +15,34 @@
 
 use core::fmt;
 
+pub trait Quantity: Sized {}
+pub trait Time: Quantity + Into<NanoSecondsU64> {}
+pub trait Frequency: Quantity + Into<HertzU64> {}
+pub trait Count: Quantity + Into<TicksU64> {}
+
+pub type ValueType = u32;
+pub type LargeValueType = u64;
+
 /// defines and implements extension traits for quantities with units
 macro_rules! define {
-    ($primitive:ident, $( $quantity:ident, $unit:ident),+) => {
+    ($primitive:ident, $trait:ident, $( ($type: ident, $quantity:ident, $unit:ident), )+) => {
         $(
             #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Default)]
             pub struct $quantity(pub $primitive);
+
+            impl Quantity for $quantity {}
+            impl $type for $quantity {}
         )*
 
-        #[allow(non_snake_case)]
-        pub trait Quantity {
+
+        pub trait $trait {
             $(
+                #[allow(non_snake_case)]
                 fn $unit(self) -> $quantity;
             )*
         }
 
-        impl Quantity for $primitive {
+        impl $trait for $primitive {
             $(
                 fn $unit(self) -> $quantity {
                     $quantity(self)
@@ -44,6 +56,7 @@ macro_rules! define {
                     x.0
                 }
             }
+
             impl From<$primitive> for $quantity {
                 fn from(x: $primitive) -> $quantity {
                     $quantity(x)
@@ -83,22 +96,21 @@ macro_rules! define {
                 }
             }
 
-
-            impl core::ops::Div for $quantity {
+            impl core::ops::Div<$quantity> for $quantity {
                 type Output = $primitive;
                 fn div(self, rhs: Self) -> Self::Output {
                     self.0/rhs.0
                 }
             }
 
-            impl core::ops::Add for $quantity {
+            impl core::ops::Add<$quantity> for $quantity {
                 type Output = Self;
                 fn add(self, rhs: Self) -> Self::Output {
                     Self(self.0+rhs.0)
                 }
             }
 
-            impl core::ops::Sub for $quantity {
+            impl core::ops::Sub<$quantity> for $quantity {
                 type Output = Self;
                 fn sub(self, rhs: Self) -> Self::Output {
                     Self(self.0-rhs.0)
@@ -108,94 +120,221 @@ macro_rules! define {
     };
 }
 
-/// defines From trait for pair or quantities with scaling
-macro_rules! convert {
-    ($from: ty, $into: ident, $factor: expr) => {
-        impl From<$from> for $into {
-            fn from(x: $from) -> Self {
-                $into(x.0 * $factor)
+/// Define ValueType and LargeValueType quantities and conversion from ValueType to LargeValueType
+macro_rules! define_u64 {
+    ($( ($type: ident, $quantity: ident, $unit:ident,
+        $quantity_u64:ident, $unit_u64:ident) ),+) => {
+        define!(
+            ValueType,
+            FromValueType,
+            $(($type, $quantity, $unit),)*
+        );
+
+        define!(
+            LargeValueType,
+            FromLargeValueType,
+            $(($type, $quantity_u64, $unit_u64),)*
+        );
+
+        $(
+        impl From<$quantity> for $quantity_u64 {
+            fn from(x: $quantity) -> Self {
+                Self(x.0 as LargeValueType)
             }
-        }
+        })*
+
     };
 }
 
-pub trait QuantityFrom<T, U, V> {
-    type Error;
-    fn from_ticks(count: T, freq: U) -> Result<V, Self::Error>;
+/// defines From trait for pair or quantities with scaling
+macro_rules! convert {
+    ($from: ty, $from_u64: ty, $into: ty, $into_u64: ty, $factor: expr) => {
+        impl From<$from> for $into {
+            fn from(x: $from) -> Self {
+                Self(x.0 * $factor)
+            }
+        }
+        impl From<$from> for $into_u64 {
+            fn from(x: $from) -> Self {
+                Self(x.0 as u64 * $factor)
+            }
+        }
+        impl From<$from_u64> for $into_u64 {
+            fn from(x: $from_u64) -> Self {
+                Self(x.0 * $factor)
+            }
+        }
+    };
 }
 
 /// defines multiply trait for frequency and time
 macro_rules! multiply {
-    ($prim:ident, $time: ty, $freq: ident, $factor: expr, $divider: expr) => {
+    ($time: ty, $time_u64: ty, $freq: ty, $freq_u64: ty,
+        $factor: expr, $divider: expr) => {
         impl core::ops::Mul<$freq> for $time {
-            type Output = $prim;
-            fn mul(self, rhs: $freq) -> $prim {
-                (self.0 as $prim) * (rhs.0 as $prim) * $factor / $divider
-            }
-        }
-        impl core::ops::Mul<$time> for $freq {
-            type Output = $prim;
-            fn mul(self, rhs: $time) -> $prim {
-                (self.0 as $prim) * (rhs.0 as $prim) * $factor / $divider
+            type Output = Ticks;
+            fn mul(self, rhs: $freq) -> Self::Output {
+                Ticks(self.0 * rhs.0 * $factor / $divider)
             }
         }
 
-        impl QuantityFrom<$prim, $freq, $time> for $time {
-            type Error = core::num::TryFromIntError;
-            fn from_ticks(count: $prim, freq: $freq) -> Result<$time, Self::Error> {
-                use core::convert::TryFrom;
-                Ok(Self(u32::try_from(
-                    (count * $divider / (freq.0 as $prim) / $factor),
-                )?))
+        impl core::ops::Mul<$time> for $freq {
+            type Output = Ticks;
+            fn mul(self, rhs: $time) -> Self::Output {
+                Ticks(self.0 * rhs.0 * $factor / $divider)
+            }
+        }
+
+        impl core::ops::Mul<$freq_u64> for $time_u64 {
+            type Output = TicksU64;
+            fn mul(self, rhs: $freq_u64) -> Self::Output {
+                TicksU64(self.0 * rhs.0 * $factor / $divider)
+            }
+        }
+
+        impl core::ops::Mul<$time_u64> for $freq_u64 {
+            type Output = TicksU64;
+            fn mul(self, rhs: $time_u64) -> Self::Output {
+                TicksU64(self.0 * rhs.0 * $factor / $divider)
+            }
+        }
+
+        impl core::ops::Mul<$freq> for $time_u64 {
+            type Output = TicksU64;
+            fn mul(self, rhs: $freq) -> Self::Output {
+                TicksU64(self.0 * rhs.0 as u64 * $factor / $divider)
+            }
+        }
+
+        impl core::ops::Mul<$time> for $freq_u64 {
+            type Output = TicksU64;
+            fn mul(self, rhs: $time) -> Self::Output {
+                TicksU64(self.0 * rhs.0 as u64 * $factor / $divider)
+            }
+        }
+
+        impl core::ops::Mul<$freq_u64> for $time {
+            type Output = TicksU64;
+            fn mul(self, rhs: $freq_u64) -> Self::Output {
+                TicksU64(self.0 as u64 * rhs.0 * $factor / $divider)
+            }
+        }
+
+        impl core::ops::Mul<$time_u64> for $freq {
+            type Output = TicksU64;
+            fn mul(self, rhs: $time_u64) -> Self::Output {
+                TicksU64(self.0 as u64 * rhs.0 * $factor / $divider)
             }
         }
     };
 }
 
-define!(
-    u32,
-    Hertz,
-    Hz,
-    KiloHertz,
-    kHz,
-    MegaHertz,
-    MHz,
-    NanoSeconds,
-    ns,
-    MicroSeconds,
-    us,
-    MilliSeconds,
-    ms,
-    Seconds,
-    s
+macro_rules! divide {
+    ($time: ty, $time_u64: ty, $freq: ty, $freq_u64: ty,
+        $factor: expr, $divider: expr) => {
+        impl core::ops::Div<$freq> for Ticks {
+            type Output = $time;
+            fn div(self, rhs: $freq) -> Self::Output {
+                (self.0 * $divider / rhs.0 / $factor).into()
+            }
+        }
+    };
+}
+
+divide!(Seconds, SecondsU64, Hertz, HertzU64, 1, 1);
+divide!(Seconds, SecondsU64, KiloHertz, KiloHertzU64, 1_000, 1);
+divide!(Seconds, SecondsU64, MegaHertz, MegaHertzU64, 1_000_000, 1);
+
+define_u64!(
+    (Frequency, Hertz, Hz, HertzU64, Hz_u64),
+    (Frequency, KiloHertz, kHz, KiloHertzU64, kHz_u64),
+    (Frequency, MegaHertz, MHz, MegaHertzU64, MHz_u64),
+    (Time, NanoSeconds, ns, NanoSecondsU64, ns_u64),
+    (Time, MicroSeconds, us, MicroSecondsU64, us_u64),
+    (Time, MilliSeconds, ms, MilliSecondsU64, ms_u64),
+    (Time, Seconds, s, SecondsU64, s_u64),
+    (Count, Ticks, ticks, TicksU64, ticks_u64)
 );
 
-convert!(KiloHertz, Hertz, 1_000);
-convert!(MegaHertz, Hertz, 1_000_000);
+convert!(KiloHertz, KiloHertzU64, Hertz, HertzU64, 1000);
 
-convert!(MegaHertz, KiloHertz, 1_000);
+convert!(MegaHertz, MegaHertzU64, Hertz, HertzU64, 1000000);
+convert!(MegaHertz, MegaHertzU64, KiloHertz, KiloHertzU64, 1000);
 
-convert!(Seconds, MilliSeconds, 1_000);
-convert!(Seconds, MicroSeconds, 1_000_000);
-convert!(Seconds, NanoSeconds, 1_000_000_000);
+convert!(Seconds, SecondsU64, MilliSeconds, MilliSecondsU64, 1000);
+convert!(Seconds, SecondsU64, MicroSeconds, MicroSecondsU64, 1000000);
+convert!(Seconds, SecondsU64, NanoSeconds, NanoSecondsU64, 1000000000);
 
-convert!(MilliSeconds, MicroSeconds, 1_000);
-convert!(MilliSeconds, NanoSeconds, 1_000_000);
+convert!(
+    MilliSeconds,
+    MilliSecondsU64,
+    MicroSeconds,
+    MicroSecondsU64,
+    1000
+);
+convert!(
+    MilliSeconds,
+    MilliSecondsU64,
+    NanoSeconds,
+    NanoSecondsU64,
+    1000000
+);
 
-convert!(MicroSeconds, NanoSeconds, 1_000);
+convert!(
+    MicroSeconds,
+    MicroSecondsU64,
+    NanoSeconds,
+    NanoSecondsU64,
+    1000
+);
 
-multiply!(u64, Seconds, Hertz, 1, 1);
-multiply!(u64, Seconds, KiloHertz, 1_000, 1);
-multiply!(u64, Seconds, MegaHertz, 1_000_000, 1);
+multiply!(Seconds, SecondsU64, Hertz, HertzU64, 1, 1);
+multiply!(Seconds, SecondsU64, KiloHertz, KiloHertzU64, 1_000, 1);
+multiply!(Seconds, SecondsU64, MegaHertz, MegaHertzU64, 1_000_000, 1);
 
-multiply!(u64, MilliSeconds, Hertz, 1, 1_000);
-multiply!(u64, MilliSeconds, KiloHertz, 1, 1);
-multiply!(u64, MilliSeconds, MegaHertz, 1_000, 1);
+multiply!(MilliSeconds, MilliSecondsU64, Hertz, HertzU64, 1, 1_000);
+multiply!(MilliSeconds, MilliSecondsU64, KiloHertz, KiloHertzU64, 1, 1);
+multiply!(
+    MilliSeconds,
+    MilliSecondsU64,
+    MegaHertz,
+    MegaHertzU64,
+    1_000,
+    1
+);
 
-multiply!(u64, MicroSeconds, Hertz, 1, 1_000_000);
-multiply!(u64, MicroSeconds, KiloHertz, 1, 1_000);
-multiply!(u64, MicroSeconds, MegaHertz, 1, 1);
+multiply!(MicroSeconds, MicroSecondsU64, Hertz, HertzU64, 1, 1_000_000);
+multiply!(
+    MicroSeconds,
+    MicroSecondsU64,
+    KiloHertz,
+    KiloHertzU64,
+    1,
+    1_000
+);
+multiply!(MicroSeconds, MicroSecondsU64, MegaHertz, MegaHertzU64, 1, 1);
 
-multiply!(u64, NanoSeconds, Hertz, 1, 1_000_000_000);
-multiply!(u64, NanoSeconds, KiloHertz, 1, 1_000_000);
-multiply!(u64, NanoSeconds, MegaHertz, 1, 1_000);
+multiply!(
+    NanoSeconds,
+    NanoSecondsU64,
+    Hertz,
+    HertzU64,
+    1,
+    1_000_000_000
+);
+multiply!(
+    NanoSeconds,
+    NanoSecondsU64,
+    KiloHertz,
+    KiloHertzU64,
+    1,
+    1_000_000
+);
+multiply!(
+    NanoSeconds,
+    NanoSecondsU64,
+    MegaHertz,
+    MegaHertzU64,
+    1,
+    1_000
+);

--- a/src/units.rs
+++ b/src/units.rs
@@ -5,16 +5,20 @@
 //! # Usage
 //!
 //! ```
-//! let frequency_mhz_1 = MegaHertz(10);
-//! let frequency_mhz_2 = 10.MHz();
-//! let frequency_khz_1: KiloHertz = frequency_mhz_1.into();
-//! let frequency_khz_2 = KiloHertz::from(frequency_mhz_2);
-//! let frequency_khz_3 = frequency_khz_1 + 10.MHz().into();
-//! let frequency_hz_1 = 1.Hz() + frequency_khz_3.into();
+//! let frequency_mhz_1 = MegaHertz(10),
+//! let frequency_mhz_2 = 10.MHz(),
+//! let frequency_khz_1: KiloHertz = frequency_mhz_1.into(),
+//! let frequency_khz_2 = KiloHertz::from(frequency_mhz_2),
+//! let frequency_khz_3 = frequency_khz_1 + 10.MHz().into(),
+//! let frequency_hz_1 = 1.Hz() + frequency_khz_3.into(),
 //! ```
 
 use core::convert::TryFrom;
+use core::convert::TryInto;
 use core::fmt;
+
+pub type ValueType = u32;
+pub type LargeValueType = u64;
 
 pub trait Quantity: Sized {}
 pub trait Time: Quantity + Into<NanoSeconds> {}
@@ -24,9 +28,6 @@ pub trait Count: Quantity + Into<Ticks> {}
 pub trait TimeU64: Quantity + Into<NanoSecondsU64> {}
 pub trait FrequencyU64: Quantity + Into<HertzU64> {}
 pub trait CountU64: Quantity + Into<TicksU64> {}
-
-pub type ValueType = u32;
-pub type LargeValueType = u64;
 
 /// defines and implements extension traits for quantities with units
 macro_rules! define {
@@ -39,7 +40,6 @@ macro_rules! define {
             impl Quantity for $quantity {}
             impl $type for $quantity {}
         )*
-
 
         pub trait $trait {
             $(
@@ -127,9 +127,10 @@ macro_rules! define {
 }
 
 /// Define ValueType and LargeValueType quantities and conversion from ValueType to LargeValueType
-macro_rules! define_u64 {
-    ($( ($type: ident, $quantity: ident, $unit:ident,
-        $type_u64: ident, $quantity_u64: ident, $unit_u64:ident, $print_unit: literal) ),+) => {
+macro_rules! define_large {
+    ($( ($type: ident, $quantity: ident, $unit:ident, $type_large: ident,
+            $quantity_large: ident, $unit_large:ident, $print_unit: literal) ),+) => {
+
         define!(
             ValueType,
             FromValueType,
@@ -139,18 +140,18 @@ macro_rules! define_u64 {
         define!(
             LargeValueType,
             FromLargeValueType,
-            $(($type_u64, $quantity_u64, $unit_u64, $print_unit),)*
+            $(($type_large, $quantity_large, $unit_large, $print_unit),)*
         );
 
         $(
-        impl From<$quantity> for $quantity_u64 {
+        impl From<$quantity> for $quantity_large {
             fn from(x: $quantity) -> Self {
-                Self(x.0 as LargeValueType)
+                Self(LargeValueType::from(x.0))
             }
         }
-        impl TryFrom<$quantity_u64> for $quantity {
+        impl TryFrom<$quantity_large> for $quantity {
             type Error=core::num::TryFromIntError;
-            fn try_from(x: $quantity_u64) -> Result<$quantity, Self::Error> {
+            fn try_from(x: $quantity_large) -> Result<$quantity, Self::Error> {
                 Ok(Self(ValueType::try_from(x.0)?))
             }
         }
@@ -161,270 +162,173 @@ macro_rules! define_u64 {
 
 /// defines From trait for pair or quantities with scaling
 macro_rules! convert {
-    ($from: ty, $from_u64: ty, $into: ty, $into_u64: ty, $factor: expr) => {
+    ($( ($from: ty, $from_large: ty, $into: ty, $into_large: ty, $factor: expr) ),+) => {
+        $(
         impl From<$from> for $into {
             fn from(x: $from) -> Self {
                 Self(x.0 * $factor)
             }
         }
-        impl From<$from> for $into_u64 {
+        impl From<$from> for $into_large {
             fn from(x: $from) -> Self {
-                Self(x.0 as u64 * $factor)
+                Self(LargeValueType::from(x.0) * $factor)
             }
         }
-        impl From<$from_u64> for $into_u64 {
-            fn from(x: $from_u64) -> Self {
+        impl From<$from_large> for $into_large {
+            fn from(x: $from_large) -> Self {
                 Self(x.0 * $factor)
             }
         }
+        )*
     };
 }
 
 /// defines multiply trait for frequency and time
 macro_rules! multiply {
-    ($time: ty, $time_u64: ty, $freq: ty, $freq_u64: ty,
-        $factor: expr, $divider: expr) => {
+    ($( ($time: ty, $time_large: ty, $freq: ty, $freq_large: ty,
+        $factor: expr, $divider: expr) ),+) => {
+        $(
         impl core::ops::Mul<$freq> for $time {
             type Output = Ticks;
             fn mul(self, rhs: $freq) -> Self::Output {
-                Ticks(
-                    (self.0 as LargeValueType * rhs.0 as LargeValueType * $factor as LargeValueType
-                        / $divider) as u32,
-                )
+                TicksU64::from(LargeValueType::from(self.0) * LargeValueType::from(rhs.0)
+                    * $factor / $divider).try_into().unwrap()
             }
         }
 
         impl core::ops::Mul<$time> for $freq {
             type Output = Ticks;
             fn mul(self, rhs: $time) -> Self::Output {
-                Ticks(self.0 * rhs.0 * $factor / $divider)
+                TicksU64::from(LargeValueType::from(self.0) * LargeValueType::from(rhs.0)
+                    * $factor / $divider).try_into().unwrap()
             }
         }
 
-        impl core::ops::Mul<$freq_u64> for $time_u64 {
+        impl core::ops::Mul<$freq_large> for $time_large {
             type Output = TicksU64;
-            fn mul(self, rhs: $freq_u64) -> Self::Output {
-                TicksU64(self.0 * rhs.0 * $factor / $divider)
+            fn mul(self, rhs: $freq_large) -> Self::Output {
+                (self.0 * rhs.0 * $factor / $divider).into()
             }
         }
 
-        impl core::ops::Mul<$time_u64> for $freq_u64 {
+        impl core::ops::Mul<$time_large> for $freq_large {
             type Output = TicksU64;
-            fn mul(self, rhs: $time_u64) -> Self::Output {
-                TicksU64(self.0 * rhs.0 * $factor / $divider)
+            fn mul(self, rhs: $time_large) -> Self::Output {
+                (self.0 * rhs.0 * $factor / $divider).into()
             }
         }
 
-        impl core::ops::Mul<$freq> for $time_u64 {
+        impl core::ops::Mul<$freq> for $time_large {
             type Output = TicksU64;
             fn mul(self, rhs: $freq) -> Self::Output {
-                TicksU64(self.0 * rhs.0 as u64 * $factor / $divider)
+                (self.0 * LargeValueType::from(rhs.0) * $factor / $divider).into()
             }
         }
 
-        impl core::ops::Mul<$time> for $freq_u64 {
+        impl core::ops::Mul<$time> for $freq_large {
             type Output = TicksU64;
             fn mul(self, rhs: $time) -> Self::Output {
-                TicksU64(self.0 * rhs.0 as u64 * $factor / $divider)
+                (self.0 * LargeValueType::from(rhs.0) * $factor / $divider).into()
             }
         }
 
-        impl core::ops::Mul<$freq_u64> for $time {
+        impl core::ops::Mul<$freq_large> for $time {
             type Output = TicksU64;
-            fn mul(self, rhs: $freq_u64) -> Self::Output {
-                TicksU64(self.0 as u64 * rhs.0 * $factor / $divider)
+            fn mul(self, rhs: $freq_large) -> Self::Output {
+                (LargeValueType::from(self.0) * rhs.0 * $factor / $divider).into()
             }
         }
 
-        impl core::ops::Mul<$time_u64> for $freq {
+        impl core::ops::Mul<$time_large> for $freq {
             type Output = TicksU64;
-            fn mul(self, rhs: $time_u64) -> Self::Output {
-                TicksU64(self.0 as u64 * rhs.0 * $factor / $divider)
+            fn mul(self, rhs: $time_large) -> Self::Output {
+                (LargeValueType::from(self.0) * rhs.0 * $factor / $divider).into()
             }
         }
+        )*
     };
 }
 
 macro_rules! divide {
-    ($freq: ty, $freq_u64: ty, $time: ty, $time_u64: ty,
-        $factor: expr, $divider: expr) => {
+    ($( ($freq: ty, $freq_large: ty, $time: ty, $time_large: ty, $factor: expr) ),+) => {
+        $(
         impl core::ops::Div<$freq> for Ticks {
             type Output = $time;
             fn div(self, rhs: $freq) -> Self::Output {
-                (self.0 * $divider / rhs.0 / $factor).into()
+                ValueType::try_from(
+                    (LargeValueType::from(self.0) * $factor / LargeValueType::from(rhs.0))
+                ).unwrap().into()
             }
         }
 
         impl core::ops::Div<$freq> for TicksU64 {
-            type Output = $time_u64;
+            type Output = $time_large;
             fn div(self, rhs: $freq) -> Self::Output {
-                (self.0 * $divider / rhs.0 as u64 / $factor).into()
+                (self.0 * $factor / LargeValueType::from(rhs.0) ).into()
             }
         }
 
-        impl core::ops::Div<$freq_u64> for TicksU64 {
-            type Output = $time_u64;
-            fn div(self, rhs: $freq_u64) -> Self::Output {
-                (self.0 * $divider / rhs.0 / $factor).into()
+        impl core::ops::Div<$freq_large> for TicksU64 {
+            type Output = $time_large;
+            fn div(self, rhs: $freq_large) -> Self::Output {
+                (self.0 * $factor / rhs.0 ).into()
             }
         }
 
-        impl core::ops::Div<$freq_u64> for Ticks {
-            type Output = $time_u64;
-            fn div(self, rhs: $freq_u64) -> Self::Output {
-                (self.0 as u64 * $divider / rhs.0 / $factor).into()
+        impl core::ops::Div<$freq_large> for Ticks {
+            type Output = $time_large;
+            fn div(self, rhs: $freq_large) -> Self::Output {
+                (LargeValueType::from(self.0) * $factor / rhs.0).into()
             }
         }
+        )*
     };
 }
 
-define_u64!(
-    (Frequency, Hertz, Hz, FrequencyU64, HertzU64, Hz_u64, "Hz"),
-    (
-        Frequency,
-        KiloHertz,
-        kHz,
-        FrequencyU64,
-        KiloHertzU64,
-        kHz_u64,
-        "kHz"
-    ),
-    (
-        Frequency,
-        MegaHertz,
-        MHz,
-        FrequencyU64,
-        MegaHertzU64,
-        MHz_u64,
-        "MHz"
-    ),
-    (Time, NanoSeconds, ns, TimeU64, NanoSecondsU64, ns_u64, "ns"),
-    (
-        Time,
-        MicroSeconds,
-        us,
-        TimeU64,
-        MicroSecondsU64,
-        us_u64,
-        "us"
-    ),
-    (
-        Time,
-        MilliSeconds,
-        ms,
-        TimeU64,
-        MilliSecondsU64,
-        ms_u64,
-        "ms"
-    ),
-    (Time, Seconds, s, TimeU64, SecondsU64, s_u64, "s"),
-    (Count, Ticks, ticks, CountU64, TicksU64, ticks_u64, "")
+#[rustfmt::skip::macros(define_large)]
+define_large!(
+    (Frequency, Hertz,        Hz,    FrequencyU64, HertzU64,        Hz_large,    "Hz"  ),
+    (Frequency, KiloHertz,    kHz,   FrequencyU64, KiloHertzU64,    kHz_large,   "kHz" ),
+    (Frequency, MegaHertz,    MHz,   FrequencyU64, MegaHertzU64,    MHz_large,   "MHz" ),
+    (Time,      NanoSeconds,  ns,    TimeU64,      NanoSecondsU64,  ns_large,    "ns"  ),
+    (Time,      MicroSeconds, us,    TimeU64,      MicroSecondsU64, us_large,    "us"  ),
+    (Time,      MilliSeconds, ms,    TimeU64,      MilliSecondsU64, ms_large,    "ms"  ),
+    (Time,      Seconds,      s,     TimeU64,      SecondsU64,      s_large,     "s"   ),
+    (Count,     Ticks,        ticks, CountU64,     TicksU64,        ticks_large, ""    )
 );
 
-convert!(KiloHertz, KiloHertzU64, Hertz, HertzU64, 1000);
-
-convert!(MegaHertz, MegaHertzU64, Hertz, HertzU64, 1000000);
-convert!(MegaHertz, MegaHertzU64, KiloHertz, KiloHertzU64, 1000);
-
-convert!(Seconds, SecondsU64, MilliSeconds, MilliSecondsU64, 1000);
-convert!(Seconds, SecondsU64, MicroSeconds, MicroSecondsU64, 1000000);
-convert!(Seconds, SecondsU64, NanoSeconds, NanoSecondsU64, 1000000000);
-
+#[rustfmt::skip::macros(convert)]
 convert!(
-    MilliSeconds,
-    MilliSecondsU64,
-    MicroSeconds,
-    MicroSecondsU64,
-    1000
-);
-convert!(
-    MilliSeconds,
-    MilliSecondsU64,
-    NanoSeconds,
-    NanoSecondsU64,
-    1000000
+    (KiloHertz,    KiloHertzU64,    Hertz,        HertzU64,        1_000         ),
+    (MegaHertz,    MegaHertzU64,    Hertz,        HertzU64,        1_000_000     ),
+    (MegaHertz,    MegaHertzU64,    KiloHertz,    KiloHertzU64,    1_000         ),
+    (Seconds,      SecondsU64,      MilliSeconds, MilliSecondsU64, 1_000         ),
+    (Seconds,      SecondsU64,      MicroSeconds, MicroSecondsU64, 1_000_000     ),
+    (Seconds,      SecondsU64,      NanoSeconds,  NanoSecondsU64,  1_000_000_000 ),
+    (MilliSeconds, MilliSecondsU64, MicroSeconds, MicroSecondsU64, 1_000         ),
+    (MilliSeconds, MilliSecondsU64, NanoSeconds,  NanoSecondsU64,  1_000_000     ),
+    (MicroSeconds, MicroSecondsU64, NanoSeconds,  NanoSecondsU64,  1_000         )
 );
 
-convert!(
-    MicroSeconds,
-    MicroSecondsU64,
-    NanoSeconds,
-    NanoSecondsU64,
-    1000
-);
-
-multiply!(Seconds, SecondsU64, Hertz, HertzU64, 1, 1);
-multiply!(Seconds, SecondsU64, KiloHertz, KiloHertzU64, 1_000, 1);
-multiply!(Seconds, SecondsU64, MegaHertz, MegaHertzU64, 1_000_000, 1);
-
-multiply!(MilliSeconds, MilliSecondsU64, Hertz, HertzU64, 1, 1_000);
-multiply!(MilliSeconds, MilliSecondsU64, KiloHertz, KiloHertzU64, 1, 1);
+#[rustfmt::skip::macros(multiply)]
 multiply!(
-    MilliSeconds,
-    MilliSecondsU64,
-    MegaHertz,
-    MegaHertzU64,
-    1_000,
-    1
+    (Seconds,      SecondsU64,      Hertz,     HertzU64,     1,         1             ),
+    (Seconds,      SecondsU64,      KiloHertz, KiloHertzU64, 1_000,     1             ),
+    (Seconds,      SecondsU64,      MegaHertz, MegaHertzU64, 1_000_000, 1             ),
+    (MilliSeconds, MilliSecondsU64, Hertz,     HertzU64,     1,         1_000         ),
+    (MilliSeconds, MilliSecondsU64, KiloHertz, KiloHertzU64, 1,         1             ),
+    (MilliSeconds, MilliSecondsU64, MegaHertz, MegaHertzU64, 1_000,     1             ),
+    (MicroSeconds, MicroSecondsU64, Hertz,     HertzU64,     1,         1_000_000     ),
+    (MicroSeconds, MicroSecondsU64, KiloHertz, KiloHertzU64, 1,         1_000         ),
+    (MicroSeconds, MicroSecondsU64, MegaHertz, MegaHertzU64, 1,         1             ),
+    (NanoSeconds,  NanoSecondsU64,  Hertz,     HertzU64,     1,         1_000_000_000 ),
+    (NanoSeconds,  NanoSecondsU64,  KiloHertz, KiloHertzU64, 1,         1_000_000     ),
+    (NanoSeconds,  NanoSecondsU64,  MegaHertz, MegaHertzU64, 1,         1_000         )
 );
 
-multiply!(MicroSeconds, MicroSecondsU64, Hertz, HertzU64, 1, 1_000_000);
-multiply!(
-    MicroSeconds,
-    MicroSecondsU64,
-    KiloHertz,
-    KiloHertzU64,
-    1,
-    1_000
-);
-multiply!(MicroSeconds, MicroSecondsU64, MegaHertz, MegaHertzU64, 1, 1);
-
-multiply!(
-    NanoSeconds,
-    NanoSecondsU64,
-    Hertz,
-    HertzU64,
-    1,
-    1_000_000_000
-);
-multiply!(
-    NanoSeconds,
-    NanoSecondsU64,
-    KiloHertz,
-    KiloHertzU64,
-    1,
-    1_000_000
-);
-multiply!(
-    NanoSeconds,
-    NanoSecondsU64,
-    MegaHertz,
-    MegaHertzU64,
-    1,
-    1_000
-);
-
+#[rustfmt::skip::macros(divide)]
 divide!(
-    Hertz,
-    HertzU64,
-    NanoSeconds,
-    NanoSecondsU64,
-    1_000_000_000,
-    1
-);
-divide!(
-    KiloHertz,
-    KiloHertzU64,
-    NanoSeconds,
-    NanoSecondsU64,
-    1_000_000,
-    1
-);
-divide!(
-    MegaHertz,
-    MegaHertzU64,
-    NanoSeconds,
-    NanoSecondsU64,
-    1_000,
-    1
+    (Hertz,     HertzU64,     NanoSeconds, NanoSecondsU64, 1_000_000_000 ),
+    (KiloHertz, KiloHertzU64, NanoSeconds, NanoSecondsU64, 1_000_000     ),
+    (MegaHertz, MegaHertzU64, NanoSeconds, NanoSecondsU64, 1_000         )
 );


### PR DESCRIPTION
Implementation of timer peripherals & watchdogs.

Chose not to include processor timer & legacy timers: these are 32 bits only and as there are already six 64-bit timers available, feels a bit superfluous for the time being.

