### PR TITLE
Added Mutexes implemented in xtensa-lx6 to prelude & started using in timers example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ procmacros/target
 **/*.rs.bk
 Cargo.lock
 .vscode/.cortex-debug*
+core

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ xtensa-lx6 = "0.2.0"
 esp32 = "0.5.0"
 bare-metal = "0.2"
 nb = "0.1.2"
-spin = "0.5.2"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
 linked_list_allocator = { version = "0.8.4", optional = true, default-features = false, features = ["alloc_ref"] }
 void = { version = "1.0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ rt = ["esp32/rt", "xtensa-lx6-rt"]
 [dependencies]
 esp32-hal-proc-macros = { path = "procmacros" }
 
-xtensa-lx6-rt = { version = "0.2.0", optional = true }
-xtensa-lx6 = "0.1.0"
-esp32 = { version = "0.5.0", default-features = false }
+xtensa-lx6-rt = { version = "0.3.0", optional = true }
+xtensa-lx6 = "0.2.0"
+esp32 = "0.5.0"
 bare-metal = "0.2"
 nb = "0.1.2"
 spin = "0.5.2"

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -5,9 +5,9 @@ extern crate esp32_hal as hal;
 extern crate panic_halt;
 extern crate xtensa_lx6_rt;
 
+use esp32_hal::target;
 use hal::prelude::*;
-use hal::target;
-use xtensa_lx6::get_cycle_count;
+use xtensa_lx6::timer::get_cycle_count;
 
 /// The default clock source is the onboard crystal
 /// In most cases 40mhz (but can be as low as 2mhz depending on the board)

--- a/examples/exception.rs
+++ b/examples/exception.rs
@@ -16,79 +16,62 @@ use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
 use esp32_hal::target;
 use esp32_hal::Core::PRO;
 
-static TX: spin::Mutex<Option<esp32_hal::serial::Tx<target::UART0>>> = spin::Mutex::new(None);
+// !!! Cannot use CriticalSectionSpinLockMutex here, because an NMI is fires from within a locked
+// section which leads to a deadlock in the NMI interrupt handler. This is not a problem in this
+// case as this is a single threaded example. !!!
+static TX: xtensa_lx6::mutex::CriticalSectionMutex<Option<esp32_hal::serial::Tx<esp32::UART0>>> =
+    xtensa_lx6::mutex::CriticalSectionMutex::new(None);
+
+fn locked_print(str: &str) {
+    (&TX).lock(|tx| {
+        let tx = tx.as_mut().unwrap();
+
+        writeln!(
+            tx,
+            "    {}, Level: {}",
+            str,
+            xtensa_lx6::interrupt::get_level()
+        )
+        .unwrap();
+    });
+}
 
 #[interrupt]
 fn FROM_CPU_INTR0() {
-    writeln!(
-        TX.lock().as_mut().unwrap(),
-        "  FROM_CPU_INTR0, level: {}",
-        xtensa_lx6::interrupt::get_level()
-    )
-    .unwrap();
+    locked_print("FROM_CPU_INTR0");
     clear_software_interrupt(Interrupt::FROM_CPU_INTR0).unwrap();
 }
 
 #[interrupt]
 fn FROM_CPU_INTR1() {
-    writeln!(
-        TX.lock().as_mut().unwrap(),
-        "  Start FROM_CPU_INTR1, level: {}",
-        xtensa_lx6::interrupt::get_level()
-    )
-    .unwrap();
+    locked_print("Start FROM_CPU_INTR1");
     interrupt::set_software_interrupt(Interrupt::FROM_CPU_INTR0).unwrap();
     interrupt::set_software_interrupt(Interrupt::FROM_CPU_INTR2).unwrap();
-    writeln!(
-        TX.lock().as_mut().unwrap(),
-        "  End FROM_CPU_INTR1, level: {}",
-        xtensa_lx6::interrupt::get_level()
-    )
-    .unwrap();
+    locked_print("End FROM_CPU_INTR1");
     clear_software_interrupt(Interrupt::FROM_CPU_INTR1).unwrap();
 }
 
 #[interrupt]
 fn FROM_CPU_INTR2() {
-    writeln!(
-        TX.lock().as_mut().unwrap(),
-        "  FROM_CPU_INTR2, level: {}",
-        xtensa_lx6::interrupt::get_level()
-    )
-    .unwrap();
+    locked_print("FROM_CPU_INTR2");
     clear_software_interrupt(Interrupt::FROM_CPU_INTR2).unwrap();
 }
 
 #[interrupt]
 fn FROM_CPU_INTR3() {
-    writeln!(
-        TX.lock().as_mut().unwrap(),
-        "  FROM_CPU_INTR3, level: {}",
-        xtensa_lx6::interrupt::get_level()
-    )
-    .unwrap();
+    locked_print("FROM_CPU_INTR3");
     clear_software_interrupt(Interrupt::FROM_CPU_INTR3).unwrap();
 }
 
 #[interrupt(INTERNAL_SOFTWARE_LEVEL_3_INTR)]
 fn software_level_3() {
-    writeln!(
-        TX.lock().as_mut().unwrap(),
-        "  INTERNAL_SOFTWARE_LEVEL_3_INTR, level: {}",
-        xtensa_lx6::interrupt::get_level()
-    )
-    .unwrap();
+    locked_print("INTERNAL_SOFTWARE_LEVEL_3_INTR");
     clear_software_interrupt(Interrupt::FROM_CPU_INTR3).unwrap();
 }
 
 #[interrupt(INTERNAL_SOFTWARE_LEVEL_1_INTR)]
 fn random_name() {
-    writeln!(
-        TX.lock().as_mut().unwrap(),
-        "  INTERNAL_SOFTWARE_LEVEL_1_INTR, level: {}",
-        xtensa_lx6::interrupt::get_level()
-    )
-    .unwrap();
+    locked_print("INTERNAL_SOFTWARE_LEVEL_1_INTR");
     clear_software_interrupt(Interrupt::FROM_CPU_INTR3).unwrap();
 }
 
@@ -98,13 +81,10 @@ fn other_exception(
     cause: xtensa_lx6_rt::exception::ExceptionCause,
     frame: xtensa_lx6_rt::exception::Context,
 ) {
-    writeln!(
-        TX.lock().as_mut().unwrap(),
-        "Exception {:?}, {:08x?}",
-        cause,
-        frame
-    )
-    .unwrap();
+    (&TX).lock(|tx| {
+        let tx = tx.as_mut().unwrap();
+        writeln!(tx, "Exception {:?}, {:08x?}", cause, frame).unwrap();
+    });
     loop {}
 }
 
@@ -156,7 +136,7 @@ fn main() -> ! {
     writeln!(uart0, "\n\nReboot!\n",).unwrap();
 
     let (tx, _) = uart0.split();
-    *TX.lock() = Some(tx);
+    (&TX).lock(|tx_locked| *tx_locked = Some(tx));
 
     interrupt::enable_with_priority(PRO, Interrupt::FROM_CPU_INTR0, InterruptLevel(2)).unwrap();
     interrupt::enable_with_priority(PRO, Interrupt::FROM_CPU_INTR1, InterruptLevel(4)).unwrap();
@@ -167,8 +147,10 @@ fn main() -> ! {
 
     // Trigger various software interrupts, because done in an interrupt free section will
     // actually trigger at the end in order of priority
-    interrupt::free(|_| {
-        writeln!(TX.lock().as_mut().unwrap(), "Start Trigger Interrupts",).unwrap();
+    (&TX).lock(|tx| {
+        let tx = tx.as_mut().unwrap();
+
+        writeln!(tx, "Start Trigger Interrupts",).unwrap();
         interrupt::set_software_interrupt(Interrupt::FROM_CPU_INTR0).unwrap();
         interrupt::set_software_interrupt(Interrupt::FROM_CPU_INTR1).unwrap();
         interrupt::set_software_interrupt(Interrupt::FROM_CPU_INTR2).unwrap();
@@ -176,11 +158,14 @@ fn main() -> ! {
         interrupt::set_software_interrupt(Interrupt::FROM_CPU_INTR3).unwrap();
         interrupt::set_software_interrupt(Interrupt::INTERNAL_SOFTWARE_LEVEL_1_INTR).unwrap();
         interrupt::set_software_interrupt(Interrupt::INTERNAL_SOFTWARE_LEVEL_3_INTR).unwrap();
-        writeln!(TX.lock().as_mut().unwrap(), "End Trigger Interrupts",).unwrap();
+        writeln!(tx, "End Trigger Interrupts",).unwrap();
     });
 
     // Trigger outside of interrupt free section, triggers immediately
-    writeln!(TX.lock().as_mut().unwrap(), "Start Trigger Interrupt",).unwrap();
+    (&TX).lock(|tx| {
+        let tx = tx.as_mut().unwrap();
+        writeln!(tx, "Start Trigger Interrupt",).unwrap();
+    });
     interrupt::set_software_interrupt(Interrupt::FROM_CPU_INTR0).unwrap();
     interrupt::set_software_interrupt(Interrupt::FROM_CPU_INTR1).unwrap();
     interrupt::set_software_interrupt(Interrupt::FROM_CPU_INTR2).unwrap();
@@ -188,11 +173,14 @@ fn main() -> ! {
     interrupt::set_software_interrupt(Interrupt::FROM_CPU_INTR3).unwrap();
     interrupt::set_software_interrupt(Interrupt::INTERNAL_SOFTWARE_LEVEL_1_INTR).unwrap();
     interrupt::set_software_interrupt(Interrupt::INTERNAL_SOFTWARE_LEVEL_3_INTR).unwrap();
-    writeln!(TX.lock().as_mut().unwrap(), "End Trigger Interrupt",).unwrap();
+
+    (&TX).lock(|tx| {
+        let tx = tx.as_mut().unwrap();
+        writeln!(tx, "End Trigger Interrupt",).unwrap();
+        writeln!(tx, "\nTrigger exception:",).unwrap();
+    });
 
     // Trigger a LoadStoreError due to unaligned access in the IRAM
-
-    writeln!(TX.lock().as_mut().unwrap(), "\nTrigger exception:",).unwrap();
 
     #[link_section = ".rwtext"]
     static mut IRAM: [u8; 12] = [0; 12];
@@ -203,8 +191,10 @@ fn main() -> ! {
 
     loop {
         sleep(1.s());
-        interrupt::free(|_| {
-            writeln!(TX.lock().as_mut().unwrap(), "Wait for watchdog reset").unwrap()
+        (&TX).lock(|tx| {
+            let tx = tx.as_mut().unwrap();
+
+            writeln!(tx, "Wait for watchdog reset").unwrap()
         });
     }
 }

--- a/examples/multicore.rs
+++ b/examples/multicore.rs
@@ -17,7 +17,8 @@ use xtensa_lx6::{get_stack_pointer, timer::get_cycle_count};
 const BLINK_HZ: Hertz = Hertz(1);
 
 static GLOBAL_COUNT: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
-static TX: spin::Mutex<Option<esp32_hal::serial::Tx<target::UART0>>> = spin::Mutex::new(None);
+static TX: CriticalSectionSpinLockMutex<Option<esp32_hal::serial::Tx<esp32::UART0>>> =
+    CriticalSectionSpinLockMutex::new(None);
 
 #[no_mangle]
 fn main() -> ! {
@@ -100,7 +101,7 @@ fn main() -> ! {
     // panic!("panic test");
 
     let (tx, _) = uart0.split();
-    *TX.lock() = Some(tx);
+    (&TX).lock(|locked_tx| *locked_tx = Some(tx));
 
     let _lock = clock_control_config.lock_cpu_frequency();
 
@@ -154,12 +155,14 @@ fn cpu1_start() -> ! {
     let mut x: u32 = 0;
     let mut prev_ccount = 0;
 
-    writeln!(
-        TX.lock().as_mut().unwrap(),
-        "Stack Pointer Core 1: {:08x?}",
-        get_stack_pointer()
-    )
-    .unwrap();
+    (&TX).lock(|tx| {
+        writeln!(
+            tx.as_mut().unwrap(),
+            "Stack Pointer Core 1: {:08x?}",
+            get_stack_pointer()
+        )
+        .unwrap()
+    });
 
     loop {
         let cycles = ClockControlConfig {}.cpu_frequency() / BLINK_HZ;
@@ -180,8 +183,9 @@ fn print_info(loop_count: u32, spin_loop_count: u32, prev_ccount: &mut u32) {
 
     let total = GLOBAL_COUNT.fetch_add(ccount_diff, core::sync::atomic::Ordering::Relaxed);
 
-    writeln!(
-        TX.lock().as_mut().unwrap(),
+    (&TX).lock(|tx| {
+
+    writeln!(tx.as_mut().unwrap(),
         "Core: {:?}, Loop: {}, Spin loops:{}, cycles: {}, cycles since previous {}, Total cycles: {}",
         esp32_hal::get_core(),
         loop_count,
@@ -191,6 +195,7 @@ fn print_info(loop_count: u32, spin_loop_count: u32, prev_ccount: &mut u32) {
         total
     )
     .unwrap();
+    });
 
     *prev_ccount = ccount;
 }

--- a/examples/multicore.rs
+++ b/examples/multicore.rs
@@ -12,7 +12,7 @@ use esp32_hal::dprintln;
 use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
 use esp32_hal::target;
 
-use xtensa_lx6::{get_cycle_count, get_stack_pointer};
+use xtensa_lx6::{get_stack_pointer, timer::get_cycle_count};
 
 const BLINK_HZ: Hertz = Hertz(1);
 
@@ -105,9 +105,7 @@ fn main() -> ! {
     let _lock = clock_control_config.lock_cpu_frequency();
 
     // start core 1 (APP_CPU)
-    clock_control_config
-        .start_core(esp32_hal::Core::APP, cpu1_start)
-        .unwrap();
+    clock_control_config.start_app_core(cpu1_start).unwrap();
 
     // main loop, which in turn lock and unlocks apb and cpu locks
     let mut x: u32 = 0;

--- a/examples/rtccntl.rs
+++ b/examples/rtccntl.rs
@@ -118,7 +118,7 @@ fn main() -> ! {
 
                 x = x.wrapping_add(1);
 
-                let ccount = xtensa_lx6::get_cycle_count();
+                let ccount = xtensa_lx6::timer::get_cycle_count();
                 let ccount_diff = ccount.wrapping_sub(prev_ccount);
 
                 writeln!(

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -142,8 +142,9 @@ fn main() -> ! {
                     if let Some(ref mut tx) = TX.lock().deref_mut() {
                         writeln!(
                             tx,
-                            "Loop: {} {} {} {} {}",
+                            "Loop: {} {:.3} {} {} {} {}",
                             x,
+                            u64::from(clkcntrl_config.rtc_nanoseconds()) as f64 / 1000000000.0,
                             timer0.get_value(),
                             timer1.get_value(),
                             timer2.get_value(),

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -148,7 +148,7 @@ fn main() -> ! {
                             timer0.get_value(),
                             timer1.get_value(),
                             timer2.get_value(),
-                            xtensa_lx6::get_cycle_count()
+                            xtensa_lx6::timer::get_cycle_count()
                         )
                         .unwrap();
                         if let Ok(_) = timer1.wait() {

--- a/src/clock_control/config.rs
+++ b/src/clock_control/config.rs
@@ -1,0 +1,212 @@
+use super::Error;
+use crate::prelude::*;
+use core::fmt;
+
+use super::{
+    dfs, CPUSource, ClockControlConfig, FastRTCSource, SlowRTCSource, CLOCK_CONTROL,
+    CLOCK_CONTROL_MUTEX,
+};
+
+impl<'a> super::ClockControlConfig {
+    // All the single word reads of frequencies and sources are thread and interrupt safe
+    // as these are atomic.
+
+    /// The current CPU frequency
+    pub fn cpu_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_frequency }
+    }
+
+    /// The current APB frequency
+    pub fn apb_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().apb_frequency }
+    }
+
+    /// The CPU frequency in the default state
+    pub fn cpu_frequency_default(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_frequency_default }
+    }
+
+    /// The CPU frequency in the CPU lock state
+    pub fn cpu_frequency_locked(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_frequency_locked }
+    }
+
+    /// The CPU frequency in the APB lock state
+    pub fn cpu_frequency_apb_locked(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_frequency_apb_locked }
+    }
+
+    /// The APB frequency in the APB lock state
+    pub fn apb_frequency_apb_locked(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().apb_frequency_apb_locked }
+    }
+
+    /// Is the reference clock 1MHz under all clock conditions
+    pub fn is_ref_clock_stable(&self) -> bool {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().ref_clock_stable }
+    }
+
+    /// The current reference frequency
+    pub fn ref_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().ref_frequency }
+    }
+
+    /// The current slow RTC frequency
+    pub fn slow_rtc_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().slow_rtc_frequency }
+    }
+
+    /// The current fast RTC frequency
+    pub fn fast_rtc_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().fast_rtc_frequency }
+    }
+
+    /// The current APLL frequency
+    pub fn apll_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().apll_frequency }
+    }
+
+    /// The current PLL/2 frequency
+    pub fn pll_d2_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().pll_d2_frequency }
+    }
+
+    /// The Xtal frequency
+    pub fn xtal_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().xtal_frequency }
+    }
+
+    /// The 32kHz Xtal frequency
+    pub fn xtal32k_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().xtal32k_frequency }
+    }
+
+    /// The current PLL frequency
+    pub fn pll_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().pll_frequency }
+    }
+
+    /// The current 8MHz oscillator frequency
+    pub fn rtc8m_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().rtc8m_frequency }
+    }
+
+    /// The current 8MHz oscillator frequency / 256
+    pub fn rtc8md256_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().rtc8md256_frequency }
+    }
+
+    /// The current 150kHz oscillator frequency
+    pub fn rtc_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().rtc_frequency }
+    }
+
+    /// The current source for the CPU and APB frequencies
+    pub fn cpu_source(&self) -> CPUSource {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_source }
+    }
+
+    /// The current source for the slow RTC frequency
+    pub fn slow_rtc_source(&self) -> SlowRTCSource {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().slow_rtc_source }
+    }
+
+    /// The current source for the fast RTC frequency
+    pub fn fast_rtc_source(&self) -> FastRTCSource {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().fast_rtc_source }
+    }
+
+    // The lock and unlock calls are thread and interrupt safe because this is handled inside
+    // the DFS routines
+
+    /// Obtain a RAII lock to use the high CPU frequency
+    pub fn lock_cpu_frequency(&self) -> dfs::LockCPU {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().lock_cpu_frequency() }
+    }
+
+    /// Obtain a RAII lock to use the APB CPU frequency
+    pub fn lock_apb_frequency(&self) -> dfs::LockAPB {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().lock_apb_frequency() }
+    }
+
+    /// Obtain a RAII lock to keep the CPU from sleeping
+    pub fn lock_awake(&self) -> dfs::LockAwake {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().lock_awake() }
+    }
+
+    /// Obtain a RAII lock to keep the PLL/2 from being turned off
+    pub fn lock_plld2(&self) -> dfs::LockPllD2 {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().lock_plld2() }
+    }
+
+    /// Add callback which will be called when clock speeds are changed.
+    ///
+    /// NOTE: these callbacks are called in an interrupt free environment,
+    /// so should be as short as possible
+    // TODO: at the moment only static lifetime callbacks are allow
+    pub fn add_callback<F>(&self, f: &'static F) -> Result<(), Error>
+    where
+        F: Fn(),
+    {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().add_callback(f) }
+    }
+
+    /// Get the current count of the PCU, APB, Awake and PLL/2 locks
+    pub fn get_lock_count(&self) -> dfs::Locks {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().get_lock_count() }
+    }
+
+    // The following routines are made thread and interrupt safe here
+
+    /// Halt the designated core
+    pub unsafe fn park_core(&mut self, core: crate::Core) {
+        interrupt::free(|_| {
+            CLOCK_CONTROL_MUTEX.lock();
+            CLOCK_CONTROL.as_mut().unwrap().park_core(core);
+        })
+    }
+
+    /// Start the APP (second) core
+    ///
+    /// The second core will start running with the function `entry`.
+    pub fn unpark_core(&mut self, core: crate::Core) {
+        interrupt::free(|_| {
+            CLOCK_CONTROL_MUTEX.lock();
+            unsafe { CLOCK_CONTROL.as_mut().unwrap().unpark_core(core) }
+        })
+    }
+
+    /// Start the APP (second) core
+    ///
+    /// The second core will start running with the function `entry`.
+    pub fn start_app_core(&mut self, entry: fn() -> !) -> Result<(), Error> {
+        interrupt::free(|_| {
+            CLOCK_CONTROL_MUTEX.lock();
+            unsafe { CLOCK_CONTROL.as_mut().unwrap().start_app_core(entry) }
+        })
+    }
+
+    // The following routines handle thread and interrupt safety themselves
+
+    /// Get RTC tick count since boot
+    ///
+    /// *Note: this function takes up to one slow RTC clock cycle (can be up to 300us) and
+    /// interrupts are blocked during this time.*
+    pub fn rtc_tick_count(&self) -> TicksU64 {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().rtc_tick_count() }
+    }
+
+    /// Get nanoseconds since boot based on RTC tick count
+    ///
+    /// *Note: this function takes up to one slow RTC clock cycle (can be up to 300us) and
+    /// interrupts are blocked during this time.*
+    pub fn rtc_nanoseconds(&self) -> NanoSecondsU64 {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().rtc_nanoseconds() }
+    }
+}
+
+impl fmt::Debug for ClockControlConfig {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().fmt(f) }
+    }
+}

--- a/src/clock_control/config.rs
+++ b/src/clock_control/config.rs
@@ -160,8 +160,7 @@ impl<'a> super::ClockControlConfig {
 
     /// Halt the designated core
     pub unsafe fn park_core(&mut self, core: crate::Core) {
-        interrupt::free(|_| {
-            CLOCK_CONTROL_MUTEX.lock();
+        (&CLOCK_CONTROL_MUTEX).lock(|_| {
             CLOCK_CONTROL.as_mut().unwrap().park_core(core);
         })
     }
@@ -170,20 +169,16 @@ impl<'a> super::ClockControlConfig {
     ///
     /// The second core will start running with the function `entry`.
     pub fn unpark_core(&mut self, core: crate::Core) {
-        interrupt::free(|_| {
-            CLOCK_CONTROL_MUTEX.lock();
-            unsafe { CLOCK_CONTROL.as_mut().unwrap().unpark_core(core) }
-        })
+        (&CLOCK_CONTROL_MUTEX)
+            .lock(|_| unsafe { CLOCK_CONTROL.as_mut().unwrap().unpark_core(core) })
     }
 
     /// Start the APP (second) core
     ///
     /// The second core will start running with the function `entry`.
     pub fn start_app_core(&mut self, entry: fn() -> !) -> Result<(), Error> {
-        interrupt::free(|_| {
-            CLOCK_CONTROL_MUTEX.lock();
-            unsafe { CLOCK_CONTROL.as_mut().unwrap().start_app_core(entry) }
-        })
+        (&CLOCK_CONTROL_MUTEX)
+            .lock(|_| unsafe { CLOCK_CONTROL.as_mut().unwrap().start_app_core(entry) })
     }
 
     // The following routines handle thread and interrupt safety themselves

--- a/src/clock_control/cpu.rs
+++ b/src/clock_control/cpu.rs
@@ -4,61 +4,51 @@
 use super::Error;
 use crate::target;
 use crate::Core::{self, APP, PRO};
-use xtensa_lx6::interrupt;
 use xtensa_lx6::set_stack_pointer;
 
 static mut START_CORE1_FUNCTION: Option<fn() -> !> = None;
 
-static CPU_MUTEX: spin::Mutex<()> = spin::Mutex::new(());
-
 impl super::ClockControl {
     pub unsafe fn park_core(&mut self, core: Core) {
-        interrupt::free(|_| {
-            let _lock = CPU_MUTEX.lock();
-
-            match core {
-                PRO => {
-                    self.rtc_control
-                        .sw_cpu_stall
-                        .modify(|_, w| w.sw_stall_procpu_c1().bits(0x21));
-                    self.rtc_control
-                        .options0
-                        .modify(|_, w| w.sw_stall_procpu_c0().bits(0x02));
-                }
-                APP => {
-                    self.rtc_control
-                        .sw_cpu_stall
-                        .modify(|_, w| w.sw_stall_appcpu_c1().bits(0x21));
-                    self.rtc_control
-                        .options0
-                        .modify(|_, w| w.sw_stall_appcpu_c0().bits(0x02));
-                }
-            };
-        });
+        match core {
+            PRO => {
+                self.rtc_control
+                    .sw_cpu_stall
+                    .modify(|_, w| w.sw_stall_procpu_c1().bits(0x21));
+                self.rtc_control
+                    .options0
+                    .modify(|_, w| w.sw_stall_procpu_c0().bits(0x02));
+            }
+            APP => {
+                self.rtc_control
+                    .sw_cpu_stall
+                    .modify(|_, w| w.sw_stall_appcpu_c1().bits(0x21));
+                self.rtc_control
+                    .options0
+                    .modify(|_, w| w.sw_stall_appcpu_c0().bits(0x02));
+            }
+        }
     }
 
     pub fn unpark_core(&mut self, core: Core) {
-        interrupt::free(|_| {
-            let _lock = CPU_MUTEX.lock();
-            match core {
-                PRO => {
-                    self.rtc_control
-                        .sw_cpu_stall
-                        .modify(|_, w| unsafe { w.sw_stall_procpu_c1().bits(0) });
-                    self.rtc_control
-                        .options0
-                        .modify(|_, w| unsafe { w.sw_stall_procpu_c0().bits(0) });
-                }
-                APP => {
-                    self.rtc_control
-                        .sw_cpu_stall
-                        .modify(|_, w| unsafe { w.sw_stall_appcpu_c1().bits(0) });
-                    self.rtc_control
-                        .options0
-                        .modify(|_, w| unsafe { w.sw_stall_appcpu_c0().bits(0) });
-                }
-            };
-        });
+        match core {
+            PRO => {
+                self.rtc_control
+                    .sw_cpu_stall
+                    .modify(|_, w| unsafe { w.sw_stall_procpu_c1().bits(0) });
+                self.rtc_control
+                    .options0
+                    .modify(|_, w| unsafe { w.sw_stall_procpu_c0().bits(0) });
+            }
+            APP => {
+                self.rtc_control
+                    .sw_cpu_stall
+                    .modify(|_, w| unsafe { w.sw_stall_appcpu_c1().bits(0) });
+                self.rtc_control
+                    .options0
+                    .modify(|_, w| unsafe { w.sw_stall_appcpu_c0().bits(0) });
+            }
+        }
     }
 
     fn flush_cache(&mut self, core: Core) {
@@ -128,58 +118,61 @@ impl super::ClockControl {
             static mut _stack_end_cpu1: u32;
         }
 
+        // disables interrupts
+        xtensa_lx6::interrupt::set_mask(0);
+
+        // reset cycle compare registers
+        xtensa_lx6::timer::set_ccompare0(0);
+        xtensa_lx6::timer::set_ccompare1(0);
+        xtensa_lx6::timer::set_ccompare2(0);
+
         // set stack pointer to end of memory: no need to retain stack up to this point
         set_stack_pointer(&mut _stack_end_cpu1);
 
         START_CORE1_FUNCTION.unwrap()();
     }
 
-    pub fn start_core(&mut self, core: Core, f: fn() -> !) -> Result<(), Error> {
-        match core {
-            PRO => return Err(Error::CoreAlreadyRunning),
-            APP => interrupt::free(|_| {
-                // no mutex lock needed here:
-                // only starts if other core not running yet
-
-                if self
-                    .dport_control
-                    .appcpu_ctrl_b()
-                    .read()
-                    .appcpu_clkgate_en()
-                    .bit_is_set()
-                {
-                    return Err(Error::CoreAlreadyRunning);
-                }
-
-                self.flush_cache(core);
-                self.enable_cache(core);
-
-                unsafe {
-                    START_CORE1_FUNCTION = Some(f);
-                }
-
-                self.dport_control.appcpu_ctrl_d().write(|w| unsafe {
-                    w.appcpu_boot_addr()
-                        .bits(Self::start_core1_init as *const u32 as u32)
-                });
-
-                self.dport_control
-                    .appcpu_ctrl_b()
-                    .modify(|_, w| w.appcpu_clkgate_en().set_bit());
-                self.dport_control
-                    .appcpu_ctrl_c()
-                    .modify(|_, w| w.appcpu_runstall().clear_bit());
-                self.dport_control
-                    .appcpu_ctrl_a()
-                    .modify(|_, w| w.appcpu_resetting().set_bit());
-                self.dport_control
-                    .appcpu_ctrl_a()
-                    .modify(|_, w| w.appcpu_resetting().clear_bit());
-
-                self.unpark_core(core);
-
-                Ok(())
-            }),
+    /// Start the APP (second) core
+    ///
+    /// The second core will start running with the function `entry`.
+    pub fn start_app_core(&mut self, entry: fn() -> !) -> Result<(), Error> {
+        if self
+            .dport_control
+            .appcpu_ctrl_b()
+            .read()
+            .appcpu_clkgate_en()
+            .bit_is_set()
+        {
+            return Err(Error::CoreAlreadyRunning);
         }
+
+        self.flush_cache(Core::APP);
+        self.enable_cache(Core::APP);
+
+        unsafe {
+            START_CORE1_FUNCTION = Some(entry);
+        }
+
+        self.dport_control.appcpu_ctrl_d().write(|w| unsafe {
+            w.appcpu_boot_addr()
+                .bits(Self::start_core1_init as *const u32 as u32)
+        });
+
+        self.dport_control
+            .appcpu_ctrl_b()
+            .modify(|_, w| w.appcpu_clkgate_en().set_bit());
+        self.dport_control
+            .appcpu_ctrl_c()
+            .modify(|_, w| w.appcpu_runstall().clear_bit());
+        self.dport_control
+            .appcpu_ctrl_a()
+            .modify(|_, w| w.appcpu_resetting().set_bit());
+        self.dport_control
+            .appcpu_ctrl_a()
+            .modify(|_, w| w.appcpu_resetting().clear_bit());
+
+        self.unpark_core(Core::APP);
+
+        Ok(())
     }
 }

--- a/src/clock_control/mod.rs
+++ b/src/clock_control/mod.rs
@@ -13,7 +13,6 @@
 //! - Implement light sleep
 //! - 32kHz Xtal support
 //! - Allow 8.5MHz clock to be tuned
-//! - Global RTC clock reading
 //! - Automatic enabling/disabling of 8MHz source (when not in use for rtc_fast_clk or cpu frequency)
 
 use crate::prelude::*;
@@ -24,8 +23,9 @@ use crate::target::rtccntl::clk_conf::*;
 use crate::target::rtccntl::cntl::*;
 use crate::target::{APB_CTRL, RTCCNTL, TIMG0};
 use core::fmt;
-use xtensa_lx6::get_cycle_count;
+use xtensa_lx6::timer::{delay, get_cycle_count};
 
+pub mod config;
 pub mod cpu;
 pub mod dfs;
 mod pll;
@@ -198,243 +198,6 @@ static CLOCK_CONTROL_MUTEX: spin::Mutex<()> = spin::Mutex::new(());
 /// high CPU and APB frequency configuration.
 #[derive(Copy, Clone)]
 pub struct ClockControlConfig {}
-
-impl<'a> ClockControlConfig {
-    // All the single word reads of frequencies and sources are thread and interrupt safe
-    // as these are atomic.
-
-    /// The current CPU frequency
-    pub fn cpu_frequency(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_frequency }
-    }
-
-    /// The current APB frequency
-    pub fn apb_frequency(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().apb_frequency }
-    }
-
-    /// The CPU frequency in the default state
-    pub fn cpu_frequency_default(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_frequency_default }
-    }
-
-    /// The CPU frequency in the CPU lock state
-    pub fn cpu_frequency_locked(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_frequency_locked }
-    }
-
-    /// The CPU frequency in the APB lock state
-    pub fn cpu_frequency_apb_locked(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_frequency_apb_locked }
-    }
-
-    /// The APB frequency in the APB lock state
-    pub fn apb_frequency_apb_locked(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().apb_frequency_apb_locked }
-    }
-
-    /// Is the reference clock 1MHz under all clock conditions
-    pub fn is_ref_clock_stable(&self) -> bool {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().ref_clock_stable }
-    }
-
-    /// The current reference frequency
-    pub fn ref_frequency(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().ref_frequency }
-    }
-
-    /// The current slow RTC frequency
-    pub fn slow_rtc_frequency(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().slow_rtc_frequency }
-    }
-
-    /// The current fast RTC frequency
-    pub fn fast_rtc_frequency(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().fast_rtc_frequency }
-    }
-
-    /// The current APLL frequency
-    pub fn apll_frequency(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().apll_frequency }
-    }
-
-    /// The current PLL/2 frequency
-    pub fn pll_d2_frequency(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().pll_d2_frequency }
-    }
-
-    /// The Xtal frequency
-    pub fn xtal_frequency(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().xtal_frequency }
-    }
-
-    /// The 32kHz Xtal frequency
-    pub fn xtal32k_frequency(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().xtal32k_frequency }
-    }
-
-    /// The current PLL frequency
-    pub fn pll_frequency(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().pll_frequency }
-    }
-
-    /// The current 8MHz oscillator frequency
-    pub fn rtc8m_frequency(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().rtc8m_frequency }
-    }
-
-    /// The current 8MHz oscillator frequency / 256
-    pub fn rtc8md256_frequency(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().rtc8md256_frequency }
-    }
-
-    /// The current 150kHz oscillator frequency
-    pub fn rtc_frequency(&self) -> Hertz {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().rtc_frequency }
-    }
-
-    /// The current source for the CPU and APB frequencies
-    pub fn cpu_source(&self) -> CPUSource {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_source }
-    }
-
-    /// The current source for the slow RTC frequency
-    pub fn slow_rtc_source(&self) -> SlowRTCSource {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().slow_rtc_source }
-    }
-
-    /// The current source for the fast RTC frequency
-    pub fn fast_rtc_source(&self) -> FastRTCSource {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().fast_rtc_source }
-    }
-
-    // The lock and unlock calls are thread and interrupt safe because this is handled inside
-    // the DFS routines
-
-    /// Obtain a RAII lock to use the high CPU frequency
-    pub fn lock_cpu_frequency(&self) -> dfs::LockCPU {
-        unsafe { CLOCK_CONTROL.as_mut().unwrap().lock_cpu_frequency() }
-    }
-
-    /// Obtain a RAII lock to use the APB CPU frequency
-    pub fn lock_apb_frequency(&self) -> dfs::LockAPB {
-        unsafe { CLOCK_CONTROL.as_mut().unwrap().lock_apb_frequency() }
-    }
-
-    /// Obtain a RAII lock to keep the CPU from sleeping
-    pub fn lock_awake(&self) -> dfs::LockAwake {
-        unsafe { CLOCK_CONTROL.as_mut().unwrap().lock_awake() }
-    }
-
-    /// Obtain a RAII lock to keep the PLL/2 from being turned off
-    pub fn lock_plld2(&self) -> dfs::LockPllD2 {
-        unsafe { CLOCK_CONTROL.as_mut().unwrap().lock_plld2() }
-    }
-
-    /// Add callback which will be called when clock speeds are changed.
-    ///
-    /// NOTE: these callbacks are called in an interrupt free environment,
-    /// so should be as short as possible
-    // TODO: at the moment only static lifetime callbacks are allow
-    pub fn add_callback<F>(&self, f: &'static F) -> Result<(), Error>
-    where
-        F: Fn(),
-    {
-        unsafe { CLOCK_CONTROL.as_mut().unwrap().add_callback(f) }
-    }
-
-    /// Get the current count of the PCU, APB, Awake and PLL/2 locks
-    pub fn get_lock_count(&self) -> dfs::Locks {
-        unsafe { CLOCK_CONTROL.as_mut().unwrap().get_lock_count() }
-    }
-
-    // The following routines are made thread and interrupt safe here
-
-    /// Halt the designated core
-    pub unsafe fn park_core(&mut self, core: crate::Core) {
-        interrupt::free(|_| {
-            CLOCK_CONTROL_MUTEX.lock();
-            CLOCK_CONTROL.as_mut().unwrap().park_core(core);
-        })
-    }
-
-    /// Start the APP (second) core
-    ///
-    /// The second core will start running with the function `entry`.
-    pub fn unpark_core(&mut self, core: crate::Core) {
-        interrupt::free(|_| {
-            CLOCK_CONTROL_MUTEX.lock();
-            unsafe { CLOCK_CONTROL.as_mut().unwrap().unpark_core(core) }
-        })
-    }
-
-    /// Start the APP (second) core
-    ///
-    /// The second core will start running with the function `entry`.
-    pub fn start_app_core(&mut self, entry: fn() -> !) -> Result<(), Error> {
-        interrupt::free(|_| {
-            CLOCK_CONTROL_MUTEX.lock();
-            unsafe { CLOCK_CONTROL.as_mut().unwrap().start_app_core(entry) }
-        })
-    }
-
-    // The following routines handle thread and interrupt safety themselves
-
-    /// Get RTC tick count since boot
-    ///
-    /// *Note: this function takes up to one slow RTC clock cycle (can be up to 300us) and
-    /// interrupts are blocked during this time.*
-    pub fn rtc_tick_count(&self) -> TicksU64 {
-        unsafe { CLOCK_CONTROL.as_mut().unwrap().rtc_tick_count() }
-    }
-
-    /// Get nanoseconds since boot based on RTC tick count
-    ///
-    /// *Note: this function takes up to one slow RTC clock cycle (can be up to 300us) and
-    /// interrupts are blocked during this time.*
-    pub fn rtc_nanoseconds(&self) -> NanoSecondsU64 {
-        unsafe { CLOCK_CONTROL.as_mut().unwrap().rtc_nanoseconds() }
-    }
-}
-
-impl fmt::Debug for ClockControlConfig {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        unsafe { CLOCK_CONTROL.as_ref().unwrap().fmt(f) }
-    }
-}
-
-/// cycle accurate delay using the cycle counter register
-pub fn delay_cycles(clocks: u32) {
-    let start = get_cycle_count();
-    loop {
-        if get_cycle_count().wrapping_sub(start) >= clocks {
-            break;
-        }
-    }
-}
-
-impl fmt::Debug for ClockControl {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("ClockControl")
-            .field("cpu_frequency", &self.cpu_frequency)
-            .field("apb_frequency", &self.apb_frequency)
-            .field("ref_frequency", &self.ref_frequency)
-            .field("apll_frequency", &self.apll_frequency)
-            .field("pll_d2_frequency", &self.pll_d2_frequency)
-            .field("slow_rtc_frequency", &self.slow_rtc_frequency)
-            .field("fast_rtc_frequency", &self.fast_rtc_frequency)
-            .field("xtal_frequency", &self.xtal_frequency)
-            .field("xtal32k_frequency", &self.xtal32k_frequency)
-            .field("rtc8m_frequency", &self.rtc8m_frequency)
-            .field("rtc8md256_frequency", &self.rtc8md256_frequency)
-            .field("rtc_frequency", &self.rtc_frequency)
-            .field("pll_frequency", &self.pll_frequency)
-            .field("cpu_source", &self.cpu_source)
-            .field("slow_rtc_source", &self.slow_rtc_source)
-            .field("fast_rtc_source", &self.fast_rtc_source)
-            .finish()
-    }
-}
 
 /// Clock Control for initialization. Once initialization is done, call the freeze function to lock
 /// the clock configuration. This will return a [ClockControlConfig](ClockControlConfig), which can
@@ -828,7 +591,7 @@ impl ClockControl {
 
     /// delay a certain time by spinning
     fn delay<T: Into<NanoSeconds>>(&self, time: T) {
-        delay_cycles(self.time_to_cpu_cycles(time));
+        delay(self.time_to_cpu_cycles(time));
     }
 
     /// Check if a value from RTC_XTAL_FREQ_REG or RTC_APB_FREQ_REG are valid clocks
@@ -1563,5 +1326,29 @@ impl ClockControl {
     /// Get nanoseconds since boot based on RTC tick count
     pub fn rtc_nanoseconds(&self) -> NanoSecondsU64 {
         self.rtc_tick_count() / self.slow_rtc_frequency
+    }
+}
+
+/// Custom debug formatter
+impl fmt::Debug for ClockControl {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ClockControl")
+            .field("cpu_frequency", &self.cpu_frequency)
+            .field("apb_frequency", &self.apb_frequency)
+            .field("ref_frequency", &self.ref_frequency)
+            .field("apll_frequency", &self.apll_frequency)
+            .field("pll_d2_frequency", &self.pll_d2_frequency)
+            .field("slow_rtc_frequency", &self.slow_rtc_frequency)
+            .field("fast_rtc_frequency", &self.fast_rtc_frequency)
+            .field("xtal_frequency", &self.xtal_frequency)
+            .field("xtal32k_frequency", &self.xtal32k_frequency)
+            .field("rtc8m_frequency", &self.rtc8m_frequency)
+            .field("rtc8md256_frequency", &self.rtc8md256_frequency)
+            .field("rtc_frequency", &self.rtc_frequency)
+            .field("pll_frequency", &self.pll_frequency)
+            .field("cpu_source", &self.cpu_source)
+            .field("slow_rtc_source", &self.slow_rtc_source)
+            .field("fast_rtc_source", &self.fast_rtc_source)
+            .finish()
     }
 }

--- a/src/clock_control/mod.rs
+++ b/src/clock_control/mod.rs
@@ -194,6 +194,9 @@ static mut CLOCK_CONTROL: Option<ClockControl> = None;
 /// Clock configuration & locking for Dynamic Frequency Switching.
 /// It allows thread and interrupt safe way to switch between default,
 /// high CPU and APB frequency configuration.
+
+// All the single word reads of frequencies and sources are thread and interrupt safe
+// as these are atomic.
 #[derive(Copy, Clone)]
 pub struct ClockControlConfig {}
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -20,3 +20,7 @@ pub use embedded_hal::digital::v2::OutputPin as _embedded_hal_digital_v2_OutputP
 pub use embedded_hal::digital::v2::StatefulOutputPin as _embedded_hal_digital_v2_StatefulOutputPin;
 pub use embedded_hal::digital::v2::ToggleableOutputPin as _embedded_hal_digital_v2_ToggleableOutputPin;
 pub use embedded_hal::prelude::*;
+pub use embedded_hal::timer::{Cancel, CountDown, Periodic};
+
+pub use xtensa_lx6::mutex::mutex_trait::prelude::*;
+pub use xtensa_lx6::mutex::CriticalSectionSpinLockMutex as MPMutex;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -23,4 +23,4 @@ pub use embedded_hal::prelude::*;
 pub use embedded_hal::timer::{Cancel, CountDown, Periodic};
 
 pub use xtensa_lx6::mutex::mutex_trait::prelude::*;
-pub use xtensa_lx6::mutex::CriticalSectionSpinLockMutex as MPMutex;
+pub use xtensa_lx6::mutex::CriticalSectionSpinLockMutex;

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -148,7 +148,7 @@ impl<INST: TimerInst> Timer<TIMG1, INST> {
     }
 }
 
-static TIMER_MUTEX: spin::Mutex<()> = spin::Mutex::new(());
+static TIMER_MUTEX: CriticalSectionSpinLockMutex<()> = CriticalSectionSpinLockMutex::new(());
 
 macro_rules! timer {
     ($TIMX:ident, $INT_ENA:ident, $CONFIG:ident, $HI:ident, $LO: ident,
@@ -170,8 +170,7 @@ macro_rules! timer {
                     Event::TimeOutEdge => self.enable_edge_interrupt(true),
                 };
                 unsafe {
-                    xtensa_lx6::interrupt::free(|_| {
-                        TIMER_MUTEX.lock();
+                    (&TIMER_MUTEX).lock(|_| {
                         (*(self.timg))
                             .int_ena_timers
                             .modify(|_, w| w.$INT_ENA().set_bit());

--- a/src/timer/watchdog.rs
+++ b/src/timer/watchdog.rs
@@ -182,8 +182,7 @@ impl<TIMG: TimerGroup> Watchdog<TIMG> {
             timg.wdtconfig4.write(|w| unsafe { w.bits(per3) });
             timg.wdtconfig5.write(|w| unsafe { w.bits(per4) });
 
-            xtensa_lx6::interrupt::free(|_| {
-                super::TIMER_MUTEX.lock();
+            (&super::TIMER_MUTEX).lock(|_| {
                 timg.int_ena_timers.modify(|_, w| w.wdt_int_ena().set_bit());
             });
             Ok(())


### PR DESCRIPTION
Starting point to use standardized Mutex implementation.
This depends on: https://github.com/esp-rs/xtensa-lx6/pull/3.

Should be expanded to be used everywhere inside esp32-hal. However the underlying trait is not yet fully stabilized.