### PR TITLE
Extensions to clock control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ procmacros/target
 **/*.rs.bk
 Cargo.lock
 .vscode/.cortex-debug*
+core

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ mem=[]
 [dependencies]
 esp32-hal-proc-macros = { path = "procmacros" }
 
-xtensa-lx6-rt = "0.2.0"
-xtensa-lx6 = "0.1.0"
+xtensa-lx6-rt = "0.3.0"
+xtensa-lx6 = "0.2.0"
 esp32 = "0.5.0"
 bare-metal = "0.2"
 nb = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ mem=[]
 [dependencies]
 esp32-hal-proc-macros = { path = "procmacros" }
 
-xtensa-lx6-rt = "0.3.0"
+xtensa-lx6-rt = "0.2.0"
 xtensa-lx6 = "0.2.0"
 esp32 = "0.5.0"
 bare-metal = "0.2"

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -6,7 +6,7 @@ extern crate panic_halt;
 extern crate xtensa_lx6_rt;
 
 use hal::prelude::*;
-use xtensa_lx6::get_cycle_count;
+use xtensa_lx6::timer::get_cycle_count;
 
 /// The default clock source is the onboard crystal
 /// In most cases 40mhz (but can be as low as 2mhz depending on the board)

--- a/examples/multicore.rs
+++ b/examples/multicore.rs
@@ -11,7 +11,7 @@ use esp32_hal::dport::Split;
 use esp32_hal::dprintln;
 use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
 
-use xtensa_lx6::{get_cycle_count, get_stack_pointer};
+use xtensa_lx6::{get_stack_pointer, timer::get_cycle_count};
 
 const BLINK_HZ: Hertz = Hertz(1);
 
@@ -104,9 +104,7 @@ fn main() -> ! {
     let _lock = clock_control_config.lock_cpu_frequency();
 
     // start core 1 (APP_CPU)
-    clock_control_config
-        .start_core(esp32_hal::Core::APP, cpu1_start)
-        .unwrap();
+    clock_control_config.start_app_core(cpu1_start).unwrap();
 
     // main loop, which in turn lock and unlocks apb and cpu locks
     let mut x: u32 = 0;

--- a/examples/rtccntl.rs
+++ b/examples/rtccntl.rs
@@ -116,7 +116,7 @@ fn main() -> ! {
 
                 x = x.wrapping_add(1);
 
-                let ccount = xtensa_lx6::get_cycle_count();
+                let ccount = xtensa_lx6::timer::get_cycle_count();
                 let ccount_diff = ccount.wrapping_sub(prev_ccount);
 
                 writeln!(

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -138,8 +138,9 @@ fn main() -> ! {
                     if let Some(ref mut tx) = TX.lock().deref_mut() {
                         writeln!(
                             tx,
-                            "Loop: {} {} {} {} {}",
+                            "Loop: {} {:.3} {} {} {} {}",
                             x,
+                            u64::from(clkcntrl_config.rtc_nanoseconds()) as f64 / 1000000000.0,
                             timer0.get_value(),
                             timer1.get_value(),
                             timer2.get_value(),

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -144,7 +144,7 @@ fn main() -> ! {
                             timer0.get_value(),
                             timer1.get_value(),
                             timer2.get_value(),
-                            xtensa_lx6::get_cycle_count()
+                            xtensa_lx6::timer::get_cycle_count()
                         )
                         .unwrap();
                         if let Ok(_) = timer1.wait() {

--- a/src/clock_control/config.rs
+++ b/src/clock_control/config.rs
@@ -1,0 +1,212 @@
+use super::Error;
+use crate::prelude::*;
+use core::fmt;
+
+use super::{
+    dfs, CPUSource, ClockControlConfig, FastRTCSource, SlowRTCSource, CLOCK_CONTROL,
+    CLOCK_CONTROL_MUTEX,
+};
+
+impl<'a> super::ClockControlConfig {
+    // All the single word reads of frequencies and sources are thread and interrupt safe
+    // as these are atomic.
+
+    /// The current CPU frequency
+    pub fn cpu_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_frequency }
+    }
+
+    /// The current APB frequency
+    pub fn apb_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().apb_frequency }
+    }
+
+    /// The CPU frequency in the default state
+    pub fn cpu_frequency_default(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_frequency_default }
+    }
+
+    /// The CPU frequency in the CPU lock state
+    pub fn cpu_frequency_locked(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_frequency_locked }
+    }
+
+    /// The CPU frequency in the APB lock state
+    pub fn cpu_frequency_apb_locked(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_frequency_apb_locked }
+    }
+
+    /// The APB frequency in the APB lock state
+    pub fn apb_frequency_apb_locked(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().apb_frequency_apb_locked }
+    }
+
+    /// Is the reference clock 1MHz under all clock conditions
+    pub fn is_ref_clock_stable(&self) -> bool {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().ref_clock_stable }
+    }
+
+    /// The current reference frequency
+    pub fn ref_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().ref_frequency }
+    }
+
+    /// The current slow RTC frequency
+    pub fn slow_rtc_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().slow_rtc_frequency }
+    }
+
+    /// The current fast RTC frequency
+    pub fn fast_rtc_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().fast_rtc_frequency }
+    }
+
+    /// The current APLL frequency
+    pub fn apll_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().apll_frequency }
+    }
+
+    /// The current PLL/2 frequency
+    pub fn pll_d2_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().pll_d2_frequency }
+    }
+
+    /// The Xtal frequency
+    pub fn xtal_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().xtal_frequency }
+    }
+
+    /// The 32kHz Xtal frequency
+    pub fn xtal32k_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().xtal32k_frequency }
+    }
+
+    /// The current PLL frequency
+    pub fn pll_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().pll_frequency }
+    }
+
+    /// The current 8MHz oscillator frequency
+    pub fn rtc8m_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().rtc8m_frequency }
+    }
+
+    /// The current 8MHz oscillator frequency / 256
+    pub fn rtc8md256_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().rtc8md256_frequency }
+    }
+
+    /// The current 150kHz oscillator frequency
+    pub fn rtc_frequency(&self) -> Hertz {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().rtc_frequency }
+    }
+
+    /// The current source for the CPU and APB frequencies
+    pub fn cpu_source(&self) -> CPUSource {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_source }
+    }
+
+    /// The current source for the slow RTC frequency
+    pub fn slow_rtc_source(&self) -> SlowRTCSource {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().slow_rtc_source }
+    }
+
+    /// The current source for the fast RTC frequency
+    pub fn fast_rtc_source(&self) -> FastRTCSource {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().fast_rtc_source }
+    }
+
+    // The lock and unlock calls are thread and interrupt safe because this is handled inside
+    // the DFS routines
+
+    /// Obtain a RAII lock to use the high CPU frequency
+    pub fn lock_cpu_frequency(&self) -> dfs::LockCPU {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().lock_cpu_frequency() }
+    }
+
+    /// Obtain a RAII lock to use the APB CPU frequency
+    pub fn lock_apb_frequency(&self) -> dfs::LockAPB {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().lock_apb_frequency() }
+    }
+
+    /// Obtain a RAII lock to keep the CPU from sleeping
+    pub fn lock_awake(&self) -> dfs::LockAwake {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().lock_awake() }
+    }
+
+    /// Obtain a RAII lock to keep the PLL/2 from being turned off
+    pub fn lock_plld2(&self) -> dfs::LockPllD2 {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().lock_plld2() }
+    }
+
+    /// Add callback which will be called when clock speeds are changed.
+    ///
+    /// NOTE: these callbacks are called in an interrupt free environment,
+    /// so should be as short as possible
+    // TODO: at the moment only static lifetime callbacks are allow
+    pub fn add_callback<F>(&self, f: &'static F) -> Result<(), Error>
+    where
+        F: Fn(),
+    {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().add_callback(f) }
+    }
+
+    /// Get the current count of the PCU, APB, Awake and PLL/2 locks
+    pub fn get_lock_count(&self) -> dfs::Locks {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().get_lock_count() }
+    }
+
+    // The following routines are made thread and interrupt safe here
+
+    /// Halt the designated core
+    pub unsafe fn park_core(&mut self, core: crate::Core) {
+        interrupt::free(|_| {
+            CLOCK_CONTROL_MUTEX.lock();
+            CLOCK_CONTROL.as_mut().unwrap().park_core(core);
+        })
+    }
+
+    /// Start the APP (second) core
+    ///
+    /// The second core will start running with the function `entry`.
+    pub fn unpark_core(&mut self, core: crate::Core) {
+        interrupt::free(|_| {
+            CLOCK_CONTROL_MUTEX.lock();
+            unsafe { CLOCK_CONTROL.as_mut().unwrap().unpark_core(core) }
+        })
+    }
+
+    /// Start the APP (second) core
+    ///
+    /// The second core will start running with the function `entry`.
+    pub fn start_app_core(&mut self, entry: fn() -> !) -> Result<(), Error> {
+        interrupt::free(|_| {
+            CLOCK_CONTROL_MUTEX.lock();
+            unsafe { CLOCK_CONTROL.as_mut().unwrap().start_app_core(entry) }
+        })
+    }
+
+    // The following routines handle thread and interrupt safety themselves
+
+    /// Get RTC tick count since boot
+    ///
+    /// *Note: this function takes up to one slow RTC clock cycle (can be up to 300us) and
+    /// interrupts are blocked during this time.*
+    pub fn rtc_tick_count(&self) -> TicksU64 {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().rtc_tick_count() }
+    }
+
+    /// Get nanoseconds since boot based on RTC tick count
+    ///
+    /// *Note: this function takes up to one slow RTC clock cycle (can be up to 300us) and
+    /// interrupts are blocked during this time.*
+    pub fn rtc_nanoseconds(&self) -> NanoSecondsU64 {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().rtc_nanoseconds() }
+    }
+}
+
+impl fmt::Debug for ClockControlConfig {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        unsafe { CLOCK_CONTROL.as_ref().unwrap().fmt(f) }
+    }
+}

--- a/src/clock_control/cpu.rs
+++ b/src/clock_control/cpu.rs
@@ -3,61 +3,51 @@
 
 use super::Error;
 use crate::Core::{self, APP, PRO};
-use xtensa_lx6::interrupt;
 use xtensa_lx6::set_stack_pointer;
 
 static mut START_CORE1_FUNCTION: Option<fn() -> !> = None;
 
-static CPU_MUTEX: spin::Mutex<()> = spin::Mutex::new(());
-
 impl super::ClockControl {
     pub unsafe fn park_core(&mut self, core: Core) {
-        interrupt::free(|_| {
-            let _lock = CPU_MUTEX.lock();
-
-            match core {
-                PRO => {
-                    self.rtc_control
-                        .sw_cpu_stall
-                        .modify(|_, w| w.sw_stall_procpu_c1().bits(0x21));
-                    self.rtc_control
-                        .options0
-                        .modify(|_, w| w.sw_stall_procpu_c0().bits(0x02));
-                }
-                APP => {
-                    self.rtc_control
-                        .sw_cpu_stall
-                        .modify(|_, w| w.sw_stall_appcpu_c1().bits(0x21));
-                    self.rtc_control
-                        .options0
-                        .modify(|_, w| w.sw_stall_appcpu_c0().bits(0x02));
-                }
-            };
-        });
+        match core {
+            PRO => {
+                self.rtc_control
+                    .sw_cpu_stall
+                    .modify(|_, w| w.sw_stall_procpu_c1().bits(0x21));
+                self.rtc_control
+                    .options0
+                    .modify(|_, w| w.sw_stall_procpu_c0().bits(0x02));
+            }
+            APP => {
+                self.rtc_control
+                    .sw_cpu_stall
+                    .modify(|_, w| w.sw_stall_appcpu_c1().bits(0x21));
+                self.rtc_control
+                    .options0
+                    .modify(|_, w| w.sw_stall_appcpu_c0().bits(0x02));
+            }
+        }
     }
 
     pub fn unpark_core(&mut self, core: Core) {
-        interrupt::free(|_| {
-            let _lock = CPU_MUTEX.lock();
-            match core {
-                PRO => {
-                    self.rtc_control
-                        .sw_cpu_stall
-                        .modify(|_, w| unsafe { w.sw_stall_procpu_c1().bits(0) });
-                    self.rtc_control
-                        .options0
-                        .modify(|_, w| unsafe { w.sw_stall_procpu_c0().bits(0) });
-                }
-                APP => {
-                    self.rtc_control
-                        .sw_cpu_stall
-                        .modify(|_, w| unsafe { w.sw_stall_appcpu_c1().bits(0) });
-                    self.rtc_control
-                        .options0
-                        .modify(|_, w| unsafe { w.sw_stall_appcpu_c0().bits(0) });
-                }
-            };
-        });
+        match core {
+            PRO => {
+                self.rtc_control
+                    .sw_cpu_stall
+                    .modify(|_, w| unsafe { w.sw_stall_procpu_c1().bits(0) });
+                self.rtc_control
+                    .options0
+                    .modify(|_, w| unsafe { w.sw_stall_procpu_c0().bits(0) });
+            }
+            APP => {
+                self.rtc_control
+                    .sw_cpu_stall
+                    .modify(|_, w| unsafe { w.sw_stall_appcpu_c1().bits(0) });
+                self.rtc_control
+                    .options0
+                    .modify(|_, w| unsafe { w.sw_stall_appcpu_c0().bits(0) });
+            }
+        }
     }
 
     fn flush_cache(&mut self, core: Core) {
@@ -127,58 +117,61 @@ impl super::ClockControl {
             static mut _stack_end_cpu1: u32;
         }
 
+        // disables interrupts
+        xtensa_lx6::interrupt::set_mask(0);
+
+        // reset cycle compare registers
+        xtensa_lx6::timer::set_ccompare0(0);
+        xtensa_lx6::timer::set_ccompare1(0);
+        xtensa_lx6::timer::set_ccompare2(0);
+
         // set stack pointer to end of memory: no need to retain stack up to this point
         set_stack_pointer(&mut _stack_end_cpu1);
 
         START_CORE1_FUNCTION.unwrap()();
     }
 
-    pub fn start_core(&mut self, core: Core, f: fn() -> !) -> Result<(), Error> {
-        match core {
-            PRO => return Err(Error::CoreAlreadyRunning),
-            APP => interrupt::free(|_| {
-                // no mutex lock needed here:
-                // only starts if other core not running yet
-
-                if self
-                    .dport_control
-                    .appcpu_ctrl_b()
-                    .read()
-                    .appcpu_clkgate_en()
-                    .bit_is_set()
-                {
-                    return Err(Error::CoreAlreadyRunning);
-                }
-
-                self.flush_cache(core);
-                self.enable_cache(core);
-
-                unsafe {
-                    START_CORE1_FUNCTION = Some(f);
-                }
-
-                self.dport_control.appcpu_ctrl_d().write(|w| unsafe {
-                    w.appcpu_boot_addr()
-                        .bits(Self::start_core1_init as *const u32 as u32)
-                });
-
-                self.dport_control
-                    .appcpu_ctrl_b()
-                    .modify(|_, w| w.appcpu_clkgate_en().set_bit());
-                self.dport_control
-                    .appcpu_ctrl_c()
-                    .modify(|_, w| w.appcpu_runstall().clear_bit());
-                self.dport_control
-                    .appcpu_ctrl_a()
-                    .modify(|_, w| w.appcpu_resetting().set_bit());
-                self.dport_control
-                    .appcpu_ctrl_a()
-                    .modify(|_, w| w.appcpu_resetting().clear_bit());
-
-                self.unpark_core(core);
-
-                Ok(())
-            }),
+    /// Start the APP (second) core
+    ///
+    /// The second core will start running with the function `entry`.
+    pub fn start_app_core(&mut self, entry: fn() -> !) -> Result<(), Error> {
+        if self
+            .dport_control
+            .appcpu_ctrl_b()
+            .read()
+            .appcpu_clkgate_en()
+            .bit_is_set()
+        {
+            return Err(Error::CoreAlreadyRunning);
         }
+
+        self.flush_cache(Core::APP);
+        self.enable_cache(Core::APP);
+
+        unsafe {
+            START_CORE1_FUNCTION = Some(entry);
+        }
+
+        self.dport_control.appcpu_ctrl_d().write(|w| unsafe {
+            w.appcpu_boot_addr()
+                .bits(Self::start_core1_init as *const u32 as u32)
+        });
+
+        self.dport_control
+            .appcpu_ctrl_b()
+            .modify(|_, w| w.appcpu_clkgate_en().set_bit());
+        self.dport_control
+            .appcpu_ctrl_c()
+            .modify(|_, w| w.appcpu_runstall().clear_bit());
+        self.dport_control
+            .appcpu_ctrl_a()
+            .modify(|_, w| w.appcpu_resetting().set_bit());
+        self.dport_control
+            .appcpu_ctrl_a()
+            .modify(|_, w| w.appcpu_resetting().clear_bit());
+
+        self.unpark_core(Core::APP);
+
+        Ok(())
     }
 }

--- a/src/clock_control/cpu.rs
+++ b/src/clock_control/cpu.rs
@@ -3,52 +3,61 @@
 
 use super::Error;
 use crate::Core::{self, APP, PRO};
+use xtensa_lx6::interrupt;
 use xtensa_lx6::set_stack_pointer;
 
 static mut START_CORE1_FUNCTION: Option<fn() -> !> = None;
 
+static CPU_MUTEX: spin::Mutex<()> = spin::Mutex::new(());
+
 impl super::ClockControl {
     pub unsafe fn park_core(&mut self, core: Core) {
-        match core {
-            PRO => {
-                self.rtc_control
-                    .sw_cpu_stall
-                    .modify(|_, w| w.sw_stall_procpu_c1().bits(0x21));
-                self.rtc_control
-                    .options0
-                    .modify(|_, w| w.sw_stall_procpu_c0().bits(0x02));
-            }
-            APP => {
-                self.rtc_control
-                    .sw_cpu_stall
-                    .modify(|_, w| w.sw_stall_appcpu_c1().bits(0x21));
-                self.rtc_control
-                    .options0
-                    .modify(|_, w| w.sw_stall_appcpu_c0().bits(0x02));
-            }
-        };
+        interrupt::free(|_| {
+            let _lock = CPU_MUTEX.lock();
+
+            match core {
+                PRO => {
+                    self.rtc_control
+                        .sw_cpu_stall
+                        .modify(|_, w| w.sw_stall_procpu_c1().bits(0x21));
+                    self.rtc_control
+                        .options0
+                        .modify(|_, w| w.sw_stall_procpu_c0().bits(0x02));
+                }
+                APP => {
+                    self.rtc_control
+                        .sw_cpu_stall
+                        .modify(|_, w| w.sw_stall_appcpu_c1().bits(0x21));
+                    self.rtc_control
+                        .options0
+                        .modify(|_, w| w.sw_stall_appcpu_c0().bits(0x02));
+                }
+            };
+        });
     }
 
     pub fn unpark_core(&mut self, core: Core) {
-        match core {
-            //TODO: check if necessary to set to 0 like in cpu_start.c?
-            PRO => {
-                self.rtc_control
-                    .sw_cpu_stall
-                    .modify(|_, w| unsafe { w.sw_stall_procpu_c1().bits(0) });
-                self.rtc_control
-                    .options0
-                    .modify(|_, w| unsafe { w.sw_stall_procpu_c0().bits(0) });
-            }
-            APP => {
-                self.rtc_control
-                    .sw_cpu_stall
-                    .modify(|_, w| unsafe { w.sw_stall_appcpu_c1().bits(0) });
-                self.rtc_control
-                    .options0
-                    .modify(|_, w| unsafe { w.sw_stall_appcpu_c0().bits(0) });
-            }
-        };
+        interrupt::free(|_| {
+            let _lock = CPU_MUTEX.lock();
+            match core {
+                PRO => {
+                    self.rtc_control
+                        .sw_cpu_stall
+                        .modify(|_, w| unsafe { w.sw_stall_procpu_c1().bits(0) });
+                    self.rtc_control
+                        .options0
+                        .modify(|_, w| unsafe { w.sw_stall_procpu_c0().bits(0) });
+                }
+                APP => {
+                    self.rtc_control
+                        .sw_cpu_stall
+                        .modify(|_, w| unsafe { w.sw_stall_appcpu_c1().bits(0) });
+                    self.rtc_control
+                        .options0
+                        .modify(|_, w| unsafe { w.sw_stall_appcpu_c0().bits(0) });
+                }
+            };
+        });
     }
 
     fn flush_cache(&mut self, core: Core) {
@@ -127,7 +136,10 @@ impl super::ClockControl {
     pub fn start_core(&mut self, core: Core, f: fn() -> !) -> Result<(), Error> {
         match core {
             PRO => return Err(Error::CoreAlreadyRunning),
-            APP => {
+            APP => interrupt::free(|_| {
+                // no mutex lock needed here:
+                // only starts if other core not running yet
+
                 if self
                     .dport_control
                     .appcpu_ctrl_b()
@@ -164,9 +176,9 @@ impl super::ClockControl {
                     .modify(|_, w| w.appcpu_resetting().clear_bit());
 
                 self.unpark_core(core);
-            }
-        }
 
-        Ok(())
+                Ok(())
+            }),
+        }
     }
 }

--- a/src/clock_control/mod.rs
+++ b/src/clock_control/mod.rs
@@ -189,17 +189,19 @@ enum CalibrateRTCSource {
 
 // static ClockControl to allow DFS, etc.
 static mut CLOCK_CONTROL: Option<ClockControl> = None;
+// mutex to allow safe multi-threaded access
+static CLOCK_CONTROL_MUTEX: spin::Mutex<()> = spin::Mutex::new(());
 
 /// Clock configuration & locking for Dynamic Frequency Switching.
 /// It allows thread and interrupt safe way to switch between default,
 /// high CPU and APB frequency configuration.
-
-// All the single word reads of frequencies and sources are thread and interrupt safe
-// as these are atomic.
 #[derive(Copy, Clone)]
 pub struct ClockControlConfig {}
 
 impl<'a> ClockControlConfig {
+    // All the single word reads of frequencies and sources are thread and interrupt safe
+    // as these are atomic.
+
     /// The current CPU frequency
     pub fn cpu_frequency(&self) -> Hertz {
         unsafe { CLOCK_CONTROL.as_ref().unwrap().cpu_frequency }
@@ -305,6 +307,9 @@ impl<'a> ClockControlConfig {
         unsafe { CLOCK_CONTROL.as_ref().unwrap().fast_rtc_source }
     }
 
+    // The lock and unlock calls are thread and interrupt safe because this is handled inside
+    // the DFS routines
+
     /// Obtain a RAII lock to use the high CPU frequency
     pub fn lock_cpu_frequency(&self) -> dfs::LockCPU {
         unsafe { CLOCK_CONTROL.as_mut().unwrap().lock_cpu_frequency() }
@@ -342,16 +347,52 @@ impl<'a> ClockControlConfig {
         unsafe { CLOCK_CONTROL.as_mut().unwrap().get_lock_count() }
     }
 
+    // The following routines are made thread and interrupt safe here
+
+    /// Halt the designated core
     pub unsafe fn park_core(&mut self, core: crate::Core) {
-        CLOCK_CONTROL.as_mut().unwrap().park_core(core)
+        interrupt::free(|_| {
+            CLOCK_CONTROL_MUTEX.lock();
+            CLOCK_CONTROL.as_mut().unwrap().park_core(core);
+        })
     }
 
+    /// Start the APP (second) core
+    ///
+    /// The second core will start running with the function `entry`.
     pub fn unpark_core(&mut self, core: crate::Core) {
-        unsafe { CLOCK_CONTROL.as_mut().unwrap().unpark_core(core) }
+        interrupt::free(|_| {
+            CLOCK_CONTROL_MUTEX.lock();
+            unsafe { CLOCK_CONTROL.as_mut().unwrap().unpark_core(core) }
+        })
     }
 
-    pub fn start_core(&mut self, core: crate::Core, f: fn() -> !) -> Result<(), Error> {
-        unsafe { CLOCK_CONTROL.as_mut().unwrap().start_core(core, f) }
+    /// Start the APP (second) core
+    ///
+    /// The second core will start running with the function `entry`.
+    pub fn start_app_core(&mut self, entry: fn() -> !) -> Result<(), Error> {
+        interrupt::free(|_| {
+            CLOCK_CONTROL_MUTEX.lock();
+            unsafe { CLOCK_CONTROL.as_mut().unwrap().start_app_core(entry) }
+        })
+    }
+
+    // The following routines handle thread and interrupt safety themselves
+
+    /// Get RTC tick count since boot
+    ///
+    /// *Note: this function takes up to one slow RTC clock cycle (can be up to 300us) and
+    /// interrupts are blocked during this time.*
+    pub fn rtc_tick_count(&self) -> TicksU64 {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().rtc_tick_count() }
+    }
+
+    /// Get nanoseconds since boot based on RTC tick count
+    ///
+    /// *Note: this function takes up to one slow RTC clock cycle (can be up to 300us) and
+    /// interrupts are blocked during this time.*
+    pub fn rtc_nanoseconds(&self) -> NanoSecondsU64 {
+        unsafe { CLOCK_CONTROL.as_mut().unwrap().rtc_nanoseconds() }
     }
 }
 
@@ -1460,5 +1501,66 @@ impl ClockControl {
             CPUSource::RTC8M => self.rtc8m_frequency_measured,
             CPUSource::APLL => unimplemented!(),
         }
+    }
+
+    /// Get RTC tick count since boot
+    ///
+    /// This function can usually take up to one RTC clock cycles (~300us).
+    ///
+    /// In exceptional circumstances it could take up to two RTC clock cycles. This can happen
+    /// when an interrupt routine or the other core calls this function exactly in between
+    /// the loop checking for the valid bit and entering the critical section.
+    ///
+    /// Interrupts are only blocked during the actual reading of the clock register,
+    /// not during the wait for valid data.
+    pub fn rtc_tick_count(&self) -> TicksU64 {
+        self.rtc_control
+            .time_update
+            .modify(|_, w| w.time_update().set_bit());
+
+        loop {
+            // do this check outside the critical section, to prevent blocking interrupts and
+            // the other core for a long time
+            while self
+                .rtc_control
+                .time_update
+                .read()
+                .time_valid()
+                .bit_is_clear()
+            {}
+
+            if let Some(ticks) = interrupt::free(|_| {
+                CLOCK_CONTROL_MUTEX.lock();
+
+                // there is a small chance that this function is interrupted or called from
+                // the other core between detecting the valid and entering the interrupt free
+                // and mutex protection reading check again inside the critical section
+
+                if self
+                    .rtc_control
+                    .time_update
+                    .read()
+                    .time_valid()
+                    .bit_is_set()
+                {
+                    // this needs to be interrupt and thread safe, because if the time value
+                    // changes in between reading the upper and lower part this results in an
+                    // invalid value.
+                    let hi = self.rtc_control.time1.read().time_hi().bits() as u64;
+                    let lo = self.rtc_control.time0.read().bits() as u64;
+                    let ticks: TicksU64 = TicksU64::from((hi << 32) | lo);
+                    Some(ticks)
+                } else {
+                    None
+                }
+            }) {
+                return ticks;
+            }
+        }
+    }
+
+    /// Get nanoseconds since boot based on RTC tick count
+    pub fn rtc_nanoseconds(&self) -> NanoSecondsU64 {
+        self.rtc_tick_count() / self.slow_rtc_frequency
     }
 }

--- a/src/clock_control/mod.rs
+++ b/src/clock_control/mod.rs
@@ -193,6 +193,9 @@ static mut CLOCK_CONTROL: Option<ClockControl> = None;
 /// Clock configuration & locking for Dynamic Frequency Switching.
 /// It allows thread and interrupt safe way to switch between default,
 /// high CPU and APB frequency configuration.
+
+// All the single word reads of frequencies and sources are thread and interrupt safe
+// as these are atomic.
 #[derive(Copy, Clone)]
 pub struct ClockControlConfig {}
 


### PR DESCRIPTION
Added support for reading the RTC clock.
Aligned to latest xtensa_lx6 version (assume 0.2.0).
Refactored Code a bit.
Added core file to .gitignore (core file sometimes created by accident).