### PR TITLE
Use crate::target pattern

### DIFF
--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -15,7 +15,7 @@ use esp32_hal::target;
 
 #[no_mangle]
 fn main() -> ! {
-    let dp = unsafe { target::Peripherals::steal() };
+    let dp = target::Peripherals::take().expect("Failed to obtain Peripherals");
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -11,10 +11,11 @@ use esp32_hal::analog::config::{Adc1Config, Adc2Config, Attenuation};
 use esp32_hal::clock_control::sleep;
 use esp32_hal::dport::Split;
 use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
+use esp32_hal::target;
 
 #[no_mangle]
 fn main() -> ! {
-    let dp = unsafe { esp32::Peripherals::steal() };
+    let dp = unsafe { target::Peripherals::steal() };
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;
@@ -80,7 +81,7 @@ fn main() -> ! {
 
 const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
 
-fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
+fn disable_timg_wdts(timg0: &mut target::TIMG0, timg1: &mut target::TIMG1) {
     timg0
         .wdtwprotect
         .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });

--- a/examples/alloc.rs
+++ b/examples/alloc.rs
@@ -49,7 +49,7 @@ macro_rules! print_info {
 
 #[entry]
 fn main() -> ! {
-    let dp = unsafe { target::Peripherals::steal() };
+    let dp = target::Peripherals::take().expect("Failed to obtain Peripherals");
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;

--- a/examples/alloc.rs
+++ b/examples/alloc.rs
@@ -19,6 +19,7 @@ use esp32_hal::clock_control::{sleep, ClockControl};
 use esp32_hal::dport::Split;
 use esp32_hal::dprintln;
 use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
+use esp32_hal::target;
 
 #[macro_use]
 extern crate alloc;
@@ -48,7 +49,7 @@ macro_rules! print_info {
 
 #[entry]
 fn main() -> ! {
-    let dp = unsafe { esp32::Peripherals::steal() };
+    let dp = unsafe { target::Peripherals::steal() };
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;
@@ -157,7 +158,7 @@ fn print_heap_info(output: &mut dyn core::fmt::Write) {
 
 const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
 
-fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
+fn disable_timg_wdts(timg0: &mut target::TIMG0, timg1: &mut target::TIMG1) {
     timg0
         .wdtwprotect
         .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -6,6 +6,7 @@ extern crate panic_halt;
 extern crate xtensa_lx6_rt;
 
 use hal::prelude::*;
+use hal::target;
 use xtensa_lx6::get_cycle_count;
 
 /// The default clock source is the onboard crystal
@@ -16,7 +17,7 @@ const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
 
 #[no_mangle]
 fn main() -> ! {
-    let dp = unsafe { hal::esp32::Peripherals::steal() };
+    let dp = unsafe { target::Peripherals::steal() };
 
     let mut rtccntl = dp.RTCCNTL;
     let mut timg0 = dp.TIMG0;
@@ -39,7 +40,7 @@ fn main() -> ! {
     }
 }
 
-fn disable_rtc_wdt(rtccntl: &mut hal::esp32::RTCCNTL) {
+fn disable_rtc_wdt(rtccntl: &mut target::RTCCNTL) {
     /* Disables the RTCWDT */
     rtccntl
         .wdtwprotect
@@ -61,7 +62,7 @@ fn disable_rtc_wdt(rtccntl: &mut hal::esp32::RTCCNTL) {
     rtccntl.wdtwprotect.write(|w| unsafe { w.bits(0x0) });
 }
 
-fn disable_timg_wdts(timg0: &mut hal::esp32::TIMG0, timg1: &mut hal::esp32::TIMG1) {
+fn disable_timg_wdts(timg0: &mut target::TIMG0, timg1: &mut target::TIMG1) {
     timg0
         .wdtwprotect
         .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -17,7 +17,7 @@ const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
 
 #[no_mangle]
 fn main() -> ! {
-    let dp = unsafe { target::Peripherals::steal() };
+    let dp = target::Peripherals::take().expect("Failed to obtain Peripherals");
 
     let mut rtccntl = dp.RTCCNTL;
     let mut timg0 = dp.TIMG0;

--- a/examples/dac.rs
+++ b/examples/dac.rs
@@ -12,7 +12,7 @@ use esp32_hal::target;
 
 #[no_mangle]
 fn main() -> ! {
-    let dp = unsafe { target::Peripherals::steal() };
+    let dp = target::Peripherals::take().expect("Failed to obtain Peripherals");
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;

--- a/examples/dac.rs
+++ b/examples/dac.rs
@@ -8,10 +8,11 @@ use esp32_hal::prelude::*;
 use esp32_hal::analog::dac::DAC;
 use esp32_hal::clock_control::sleep;
 use esp32_hal::dport::Split;
+use esp32_hal::target;
 
 #[no_mangle]
 fn main() -> ! {
-    let dp = unsafe { esp32::Peripherals::steal() };
+    let dp = unsafe { target::Peripherals::steal() };
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;
@@ -60,7 +61,7 @@ fn main() -> ! {
 
 const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
 
-fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
+fn disable_timg_wdts(timg0: &mut target::TIMG0, timg1: &mut target::TIMG1) {
     timg0
         .wdtwprotect
         .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });

--- a/examples/exception.rs
+++ b/examples/exception.rs
@@ -13,9 +13,10 @@ use esp32_hal::dport::Split;
 use esp32_hal::dprintln;
 use esp32_hal::interrupt::{clear_software_interrupt, Interrupt, Interrupt::*, InterruptLevel};
 use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
+use esp32_hal::target;
 use esp32_hal::Core::PRO;
 
-static TX: spin::Mutex<Option<esp32_hal::serial::Tx<esp32::UART0>>> = spin::Mutex::new(None);
+static TX: spin::Mutex<Option<esp32_hal::serial::Tx<target::UART0>>> = spin::Mutex::new(None);
 
 #[interrupt]
 fn FROM_CPU_INTR0() {
@@ -109,7 +110,7 @@ fn other_exception(
 
 #[entry]
 fn main() -> ! {
-    let dp = esp32::Peripherals::take().unwrap();
+    let dp = target::Peripherals::take().unwrap();
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;
@@ -210,7 +211,7 @@ fn main() -> ! {
 
 const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
 
-fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
+fn disable_timg_wdts(timg0: &mut target::TIMG0, timg1: &mut target::TIMG1) {
     timg0
         .wdtwprotect
         .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });

--- a/examples/hall.rs
+++ b/examples/hall.rs
@@ -15,7 +15,7 @@ use esp32_hal::target;
 
 #[no_mangle]
 fn main() -> ! {
-    let dp = unsafe { target::Peripherals::steal() };
+    let dp = target::Peripherals::take().expect("Failed to obtain Peripherals");
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;

--- a/examples/hall.rs
+++ b/examples/hall.rs
@@ -11,10 +11,11 @@ use esp32_hal::analog::config::{Adc1Config, Attenuation};
 use esp32_hal::clock_control::sleep;
 use esp32_hal::dport::Split;
 use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
+use esp32_hal::target;
 
 #[no_mangle]
 fn main() -> ! {
-    let dp = unsafe { esp32::Peripherals::steal() };
+    let dp = unsafe { target::Peripherals::steal() };
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;
@@ -74,7 +75,7 @@ fn main() -> ! {
 
 const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
 
-fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
+fn disable_timg_wdts(timg0: &mut target::TIMG0, timg1: &mut target::TIMG1) {
     timg0
         .wdtwprotect
         .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });

--- a/examples/mem.rs
+++ b/examples/mem.rs
@@ -27,7 +27,7 @@ pub static GLOBAL_ALLOCATOR: Allocator = DRAM_ALLOCATOR;
 
 #[entry]
 fn main() -> ! {
-    let dp = unsafe { target::Peripherals::steal() };
+    let dp = target::Peripherals::take().expect("Failed to obtain Peripherals");
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;

--- a/examples/mem.rs
+++ b/examples/mem.rs
@@ -15,6 +15,7 @@ use esp32_hal::dport::Split;
 use esp32_hal::dprintln;
 use esp32_hal::mem::{memcmp, memcpy, memcpy_reverse, memset};
 use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
+use esp32_hal::target;
 
 use xtensa_lx6::get_cycle_count;
 
@@ -26,7 +27,7 @@ pub static GLOBAL_ALLOCATOR: Allocator = DRAM_ALLOCATOR;
 
 #[entry]
 fn main() -> ! {
-    let dp = unsafe { esp32::Peripherals::steal() };
+    let dp = unsafe { target::Peripherals::steal() };
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;
@@ -186,7 +187,7 @@ unsafe fn time_memcpy(
 
 const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
 
-fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
+fn disable_timg_wdts(timg0: &mut target::TIMG0, timg1: &mut target::TIMG1) {
     timg0
         .wdtwprotect
         .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });

--- a/examples/multicore.rs
+++ b/examples/multicore.rs
@@ -10,17 +10,18 @@ use esp32_hal::clock_control::{CPUSource, ClockControl, ClockControlConfig};
 use esp32_hal::dport::Split;
 use esp32_hal::dprintln;
 use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
+use esp32_hal::target;
 
 use xtensa_lx6::{get_cycle_count, get_stack_pointer};
 
 const BLINK_HZ: Hertz = Hertz(1);
 
 static GLOBAL_COUNT: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
-static TX: spin::Mutex<Option<esp32_hal::serial::Tx<esp32::UART0>>> = spin::Mutex::new(None);
+static TX: spin::Mutex<Option<esp32_hal::serial::Tx<target::UART0>>> = spin::Mutex::new(None);
 
 #[no_mangle]
 fn main() -> ! {
-    let dp = unsafe { esp32::Peripherals::steal() };
+    let dp = unsafe { target::Peripherals::steal() };
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;
@@ -198,7 +199,7 @@ fn print_info(loop_count: u32, spin_loop_count: u32, prev_ccount: &mut u32) {
 
 const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
 
-fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
+fn disable_timg_wdts(timg0: &mut target::TIMG0, timg1: &mut target::TIMG1) {
     timg0
         .wdtwprotect
         .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });

--- a/examples/multicore.rs
+++ b/examples/multicore.rs
@@ -21,7 +21,7 @@ static TX: spin::Mutex<Option<esp32_hal::serial::Tx<target::UART0>>> = spin::Mut
 
 #[no_mangle]
 fn main() -> ! {
-    let dp = unsafe { target::Peripherals::steal() };
+    let dp = target::Peripherals::take().expect("Failed to obtain Peripherals");
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;

--- a/examples/ram.rs
+++ b/examples/ram.rs
@@ -10,12 +10,13 @@ use esp32_hal::clock_control::{sleep, ClockControl};
 use esp32_hal::dport::Split;
 use esp32_hal::dprintln;
 use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
+use esp32_hal::target;
 
 use xtensa_lx6::get_program_counter;
 
 #[entry]
 fn main() -> ! {
-    let dp = unsafe { esp32::Peripherals::steal() };
+    let dp = unsafe { target::Peripherals::steal() };
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;
@@ -65,7 +66,7 @@ fn main() -> ! {
     }
 }
 
-fn attr_none_fn(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
+fn attr_none_fn(uart: &mut esp32_hal::serial::Serial<target::UART0, (NoTx, NoRx)>) {
     writeln!(
         uart,
         "{:<40}: {:08x?}",
@@ -76,7 +77,7 @@ fn attr_none_fn(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>
 }
 
 #[ram]
-fn attr_ram_fn(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
+fn attr_ram_fn(uart: &mut esp32_hal::serial::Serial<target::UART0, (NoTx, NoRx)>) {
     writeln!(
         uart,
         "{:<40}: {:08x?}",
@@ -87,7 +88,7 @@ fn attr_ram_fn(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>)
 }
 
 #[ram(rtc_slow)]
-fn attr_ram_fn_rtc_slow(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
+fn attr_ram_fn_rtc_slow(uart: &mut esp32_hal::serial::Serial<target::UART0, (NoTx, NoRx)>) {
     writeln!(
         uart,
         "{:<40}: {:08x?}",
@@ -98,7 +99,7 @@ fn attr_ram_fn_rtc_slow(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx
 }
 
 #[ram(rtc_fast)]
-fn attr_ram_fn_rtc_fast(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
+fn attr_ram_fn_rtc_fast(uart: &mut esp32_hal::serial::Serial<target::UART0, (NoTx, NoRx)>) {
     writeln!(
         uart,
         "{:<40}: {:08x?}",
@@ -169,7 +170,7 @@ macro_rules! print_info {
     };
 }
 
-fn ram_tests(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
+fn ram_tests(uart: &mut esp32_hal::serial::Serial<target::UART0, (NoTx, NoRx)>) {
     writeln!(uart).unwrap();
 
     attr_none_fn(uart);
@@ -206,10 +207,10 @@ fn ram_tests(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
 }
 
 #[cfg(not(feature = "external_ram"))]
-fn external_ram(_uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {}
+fn external_ram(_uart: &mut esp32_hal::serial::Serial<target::UART0, (NoTx, NoRx)>) {}
 
 #[cfg(feature = "external_ram")]
-fn external_ram(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>) {
+fn external_ram(uart: &mut esp32_hal::serial::Serial<target::UART0, (NoTx, NoRx)>) {
     unsafe {
         print_info!(uart, ATTR_RAM_STATIC_EXTERNAL);
         print_info!(uart, ATTR_RAM_STATIC_EXTERNAL_BSS);
@@ -219,7 +220,7 @@ fn external_ram(uart: &mut esp32_hal::serial::Serial<esp32::UART0, (NoTx, NoRx)>
 
 const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
 
-fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
+fn disable_timg_wdts(timg0: &mut target::TIMG0, timg1: &mut target::TIMG1) {
     timg0
         .wdtwprotect
         .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });

--- a/examples/ram.rs
+++ b/examples/ram.rs
@@ -16,7 +16,7 @@ use xtensa_lx6::get_program_counter;
 
 #[entry]
 fn main() -> ! {
-    let dp = unsafe { target::Peripherals::steal() };
+    let dp = target::Peripherals::take().expect("Failed to obtain Peripherals");
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;

--- a/examples/rtccntl.rs
+++ b/examples/rtccntl.rs
@@ -16,7 +16,7 @@ const BLINK_HZ: Hertz = Hertz(1);
 
 #[no_mangle]
 fn main() -> ! {
-    let dp = unsafe { target::Peripherals::steal() };
+    let dp = target::Peripherals::take().expect("Failed to obtain Peripherals");
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;

--- a/examples/rtccntl.rs
+++ b/examples/rtccntl.rs
@@ -10,11 +10,13 @@ use esp32_hal::clock_control::{sleep, CPUSource, ClockControl, ClockControlConfi
 use esp32_hal::dport::Split;
 use esp32_hal::dprintln;
 use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
+use esp32_hal::target;
+
 const BLINK_HZ: Hertz = Hertz(1);
 
 #[no_mangle]
 fn main() -> ! {
-    let dp = unsafe { esp32::Peripherals::steal() };
+    let dp = unsafe { target::Peripherals::steal() };
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;
@@ -146,7 +148,7 @@ fn main() -> ! {
 
 const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
 
-fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
+fn disable_timg_wdts(timg0: &mut target::TIMG0, timg1: &mut target::TIMG1) {
     timg0
         .wdtwprotect
         .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -16,7 +16,7 @@ const BLINK_HZ: Hertz = Hertz(2);
 
 #[no_mangle]
 fn main() -> ! {
-    let dp = unsafe { target::Peripherals::steal() };
+    let dp = target::Peripherals::take().expect("Failed to obtain Peripherals");
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -10,12 +10,13 @@ use esp32_hal::prelude::*;
 use esp32_hal::clock_control::sleep;
 use esp32_hal::dport::Split;
 use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
+use esp32_hal::target;
 
 const BLINK_HZ: Hertz = Hertz(2);
 
 #[no_mangle]
 fn main() -> ! {
-    let dp = unsafe { esp32::Peripherals::steal() };
+    let dp = unsafe { target::Peripherals::steal() };
 
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;
@@ -71,7 +72,7 @@ fn main() -> ! {
 
 const WDT_WKEY_VALUE: u32 = 0x50D83AA1;
 
-fn disable_timg_wdts(timg0: &mut esp32::TIMG0, timg1: &mut esp32::TIMG1) {
+fn disable_timg_wdts(timg0: &mut target::TIMG0, timg1: &mut target::TIMG1) {
     timg0
         .wdtwprotect
         .write(|w| unsafe { w.bits(WDT_WKEY_VALUE) });

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -14,6 +14,7 @@ use esp32_hal::dport::Split;
 use esp32_hal::dprintln;
 use esp32_hal::interrupt::{Interrupt, InterruptLevel};
 use esp32_hal::serial::{config::Config, NoRx, NoTx, Serial};
+use esp32_hal::target;
 use esp32_hal::timer::watchdog::{self, WatchDogResetDuration, WatchdogAction, WatchdogConfig};
 use esp32_hal::timer::{Timer, Timer0, Timer1, TimerLact, TimerWithInterrupt};
 use esp32_hal::Core::PRO;
@@ -21,21 +22,24 @@ use spin::Mutex;
 
 const BLINK_HZ: Hertz = Hertz(2);
 
-static TIMER0: Mutex<RefCell<Option<Timer<esp32::TIMG0, Timer0>>>> = Mutex::new(RefCell::new(None));
-static TIMER2: Mutex<RefCell<Option<Timer<esp32::TIMG0, TimerLact>>>> =
+static TIMER0: Mutex<RefCell<Option<Timer<target::TIMG0, Timer0>>>> =
     Mutex::new(RefCell::new(None));
-static TIMER3: Mutex<RefCell<Option<Timer<esp32::TIMG1, Timer0>>>> = Mutex::new(RefCell::new(None));
-static TIMER4: Mutex<RefCell<Option<Timer<esp32::TIMG1, Timer1>>>> = Mutex::new(RefCell::new(None));
-static TIMER5: Mutex<RefCell<Option<Timer<esp32::TIMG1, TimerLact>>>> =
+static TIMER2: Mutex<RefCell<Option<Timer<target::TIMG0, TimerLact>>>> =
+    Mutex::new(RefCell::new(None));
+static TIMER3: Mutex<RefCell<Option<Timer<target::TIMG1, Timer0>>>> =
+    Mutex::new(RefCell::new(None));
+static TIMER4: Mutex<RefCell<Option<Timer<target::TIMG1, Timer1>>>> =
+    Mutex::new(RefCell::new(None));
+static TIMER5: Mutex<RefCell<Option<Timer<target::TIMG1, TimerLact>>>> =
     Mutex::new(RefCell::new(None));
 
-static WATCHDOG1: Mutex<RefCell<Option<watchdog::Watchdog<esp32::TIMG1>>>> =
+static WATCHDOG1: Mutex<RefCell<Option<watchdog::Watchdog<target::TIMG1>>>> =
     Mutex::new(RefCell::new(None));
-static TX: Mutex<Option<esp32_hal::serial::Tx<esp32::UART0>>> = spin::Mutex::new(None);
+static TX: Mutex<Option<esp32_hal::serial::Tx<target::UART0>>> = spin::Mutex::new(None);
 
 #[no_mangle]
 fn main() -> ! {
-    let dp = esp32::Peripherals::take().unwrap();
+    let dp = target::Peripherals::take().unwrap();
 
     let (mut dport, dport_clock_control) = dp.DPORT.split();
 

--- a/src/analog/adc.rs
+++ b/src/analog/adc.rs
@@ -21,11 +21,11 @@
 
 use core::marker::PhantomData;
 use embedded_hal::adc::{Channel, OneShot};
-use esp32::{RTCIO, SENS};
 
 use crate::analog::config;
 use crate::analog::{ADC1, ADC2};
 use crate::gpio::*;
+use crate::target::{RTCIO, SENS};
 
 pub struct ADC<ADC> {
     adc: PhantomData<ADC>,

--- a/src/analog/dac.rs
+++ b/src/analog/dac.rs
@@ -7,10 +7,10 @@
 //!
 
 use core::marker::PhantomData;
-use esp32::{RTCIO, SENS};
 
 use crate::analog::{DAC1, DAC2};
 use crate::gpio::{Analog, Gpio25, Gpio26};
+use crate::target::{RTCIO, SENS};
 
 pub struct DAC<DAC> {
     _dac: PhantomData<DAC>,

--- a/src/analog/hall.rs
+++ b/src/analog/hall.rs
@@ -5,11 +5,11 @@
 //!
 
 use embedded_hal::adc::OneShot;
-use esp32::RTCIO;
 
 use crate::analog::adc::ADC;
 use crate::analog::ADC1;
 use crate::gpio::{Analog, Gpio36, Gpio39};
+use crate::target::RTCIO;
 
 impl ADC<ADC1> {
     pub fn read_hall_sensor(

--- a/src/analog/mod.rs
+++ b/src/analog/mod.rs
@@ -9,8 +9,8 @@ pub mod config;
 pub mod dac;
 pub mod hall;
 
+use crate::target::SENS;
 use core::marker::PhantomData;
-use esp32::SENS;
 
 pub struct ADC1 {
     _private: PhantomData<()>,

--- a/src/clock_control/cpu.rs
+++ b/src/clock_control/cpu.rs
@@ -2,6 +2,7 @@
 //!
 
 use super::Error;
+use crate::target;
 use crate::Core::{self, APP, PRO};
 use xtensa_lx6::set_stack_pointer;
 
@@ -95,7 +96,7 @@ impl super::ClockControl {
     fn enable_cache(&mut self, core: Core) {
         // get timer group 0 registers, do it this way instead of
         // having to pass in yet another peripheral for this clock control
-        let spi0 = unsafe { &(*esp32::SPI0::ptr()) };
+        let spi0 = unsafe { &(*target::SPI0::ptr()) };
 
         match core {
             PRO => {

--- a/src/clock_control/mod.rs
+++ b/src/clock_control/mod.rs
@@ -17,12 +17,13 @@
 //! - Automatic enabling/disabling of 8MHz source (when not in use for rtc_fast_clk or cpu frequency)
 
 use crate::prelude::*;
+use crate::target;
+use crate::target::dport::cpu_per_conf::CPUPERIOD_SEL_A;
+use crate::target::generic::Variant::*;
+use crate::target::rtccntl::clk_conf::*;
+use crate::target::rtccntl::cntl::*;
+use crate::target::{APB_CTRL, RTCCNTL, TIMG0};
 use core::fmt;
-use esp32::dport::cpu_per_conf::CPUPERIOD_SEL_A;
-use esp32::generic::Variant::*;
-use esp32::rtccntl::clk_conf::*;
-use esp32::rtccntl::cntl::*;
-use esp32::{APB_CTRL, RTCCNTL, TIMG0};
 use xtensa_lx6::get_cycle_count;
 
 pub mod cpu;
@@ -639,9 +640,9 @@ impl ClockControl {
         }
 
         let rtc_source = match source {
-            CalibrateRTCSource::SlowRTC => esp32::timg::rtccalicfg::CLK_SEL_A::RTC_MUX,
-            CalibrateRTCSource::RTC8MD256 => esp32::timg::rtccalicfg::CLK_SEL_A::CK8M_D256,
-            CalibrateRTCSource::Xtal32k => esp32::timg::rtccalicfg::CLK_SEL_A::XTAL32K,
+            CalibrateRTCSource::SlowRTC => target::timg::rtccalicfg::CLK_SEL_A::RTC_MUX,
+            CalibrateRTCSource::RTC8MD256 => target::timg::rtccalicfg::CLK_SEL_A::CK8M_D256,
+            CalibrateRTCSource::Xtal32k => target::timg::rtccalicfg::CLK_SEL_A::XTAL32K,
         };
 
         // get timer group 0 registers, do it this way instead of
@@ -1229,7 +1230,7 @@ impl ClockControl {
         unsafe {
             timg0.rtccalicfg.modify(|_, w| {
                 w.clk_sel()
-                    .variant(esp32::timg::rtccalicfg::CLK_SEL_A::RTC_MUX)
+                    .variant(target::timg::rtccalicfg::CLK_SEL_A::RTC_MUX)
                     .max()
                     .bits(0)
                     .start_cycling()

--- a/src/clock_control/pll.rs
+++ b/src/clock_control/pll.rs
@@ -3,7 +3,7 @@
 
 use super::Error;
 use crate::prelude::*;
-use esp32::generic::Variant::Val;
+use crate::target::generic::Variant::Val;
 
 // Delays (in microseconds) for changing pll settings
 // TODO according to esp-idf: some of these are excessive, and should be reduced.

--- a/src/clock_control/watchdog.rs
+++ b/src/clock_control/watchdog.rs
@@ -5,10 +5,11 @@
 //! - Consider add default configuration for start with time only
 
 use crate::prelude::*;
+use crate::target;
+use crate::target::generic::Variant::Val;
+use crate::target::rtccntl::wdtconfig0::*;
+use crate::target::RTCCNTL;
 use embedded_hal::watchdog::{WatchdogDisable, WatchdogEnable};
-use esp32::generic::Variant::Val;
-use esp32::rtccntl::wdtconfig0::*;
-use esp32::RTCCNTL;
 
 pub type WatchdogAction = WDT_STG0_A;
 pub type WatchDogResetDuration = WDT_CPU_RESET_LENGTH_A;
@@ -64,7 +65,7 @@ impl Watchdog {
     }
 
     /// function to unlock the watchdog (write unblock key) and lock after use
-    fn access_registers<A, F: FnMut(&esp32::rtccntl::RegisterBlock) -> A>(
+    fn access_registers<A, F: FnMut(&target::rtccntl::RegisterBlock) -> A>(
         &mut self,
         mut f: F,
     ) -> A {

--- a/src/dport.rs
+++ b/src/dport.rs
@@ -3,7 +3,7 @@
 //! This peripheral contains many registers, which are used for various different functions.
 //! Registers needed in other blocks can be split off.
 //!
-use esp32::{dport, DPORT};
+use crate::target::{dport, DPORT};
 
 /// Cpu Period Configuration Register
 pub struct ClockControl {}

--- a/src/dprint.rs
+++ b/src/dprint.rs
@@ -4,7 +4,7 @@
 //! This is unsafe! It is asynchronous with normal UART0 usage and
 //! interrupts are not disabled.
 
-use esp32::UART0;
+use crate::target::UART0;
 
 pub struct DebugLog {}
 

--- a/src/efuse.rs
+++ b/src/efuse.rs
@@ -1,7 +1,7 @@
 #![allow(non_camel_case_types)]
 
 use crate::prelude::*;
-use esp32::EFUSE;
+use crate::target::EFUSE;
 
 pub struct Efuse;
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,5 +1,5 @@
 use {
-    crate::esp32::{GPIO, IO_MUX, RTCIO},
+    crate::target::{GPIO, IO_MUX, RTCIO},
     core::{convert::Infallible, marker::PhantomData},
     embedded_hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin, ToggleableOutputPin},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 #![cfg_attr(feature = "alloc", feature(alloc_layout_extra))]
 
 pub use embedded_hal as hal;
-pub use esp32;
+pub use esp32 as target;
 
 extern crate esp32_hal_proc_macros as proc_macros;
 pub use proc_macros::interrupt;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -15,7 +15,8 @@ use core::marker::PhantomData;
 
 use embedded_hal::serial;
 
-use crate::esp32::{UART0, UART1, UART2};
+use crate::target;
+use crate::target::{UART0, UART1, UART2};
 use crate::units::*;
 
 const UART_FIFO_SIZE: u8 = 128;
@@ -182,7 +183,7 @@ macro_rules! halUart {
                     pins: PINS,
                     config: config::Config,
                     clock_control:  crate::clock_control::ClockControlConfig,
-                    dport: &mut esp32::DPORT
+                    dport: &mut target::DPORT
                 ) -> Result<Self, Error>
                 where
                     PINS: Pins<$UARTX>,
@@ -198,20 +199,20 @@ macro_rules! halUart {
                         Ok(serial)
                 }
 
-                fn reset(&mut self, dport:&mut esp32::DPORT) -> &mut Self {
+                fn reset(&mut self, dport:&mut target::DPORT) -> &mut Self {
                     dport.perip_rst_en.modify(|_,w| w.$uartX().set_bit());
                     dport.perip_rst_en.modify(|_,w| w.$uartX().clear_bit());
                     self
                 }
 
-                pub fn enable(&mut self, dport:&mut esp32::DPORT) -> &mut Self {
+                pub fn enable(&mut self, dport:&mut target::DPORT) -> &mut Self {
                     dport.perip_clk_en.modify(|_,w| w.uart_mem().set_bit());
                     dport.perip_clk_en.modify(|_,w| w.$uartX().set_bit());
                     dport.perip_rst_en.modify(|_,w| w.$uartX().clear_bit());
                     self
                 }
 
-                pub fn disable(&mut self, dport:&mut esp32::DPORT) -> &mut Self {
+                pub fn disable(&mut self, dport:&mut target::DPORT) -> &mut Self {
                     dport.perip_clk_en.modify(|_,w| w.$uartX().clear_bit());
                     dport.perip_rst_en.modify(|_,w| w.$uartX().set_bit());
 

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -13,8 +13,9 @@ use embedded_hal::timer::{Cancel, CountDown, Periodic};
 
 use crate::clock_control::ClockControlConfig;
 use crate::prelude::*;
+use crate::target;
+use crate::target::{TIMG0, TIMG1};
 use core::marker::PhantomData;
-use esp32::{TIMG0, TIMG1};
 
 pub mod watchdog;
 
@@ -38,7 +39,7 @@ pub enum Error {
 /// Lower level access is provided by the other functions.
 pub struct Timer<TIMG: TimerGroup, INST: TimerInst> {
     clock_control_config: ClockControlConfig,
-    timg: *const esp32::timg::RegisterBlock,
+    timg: *const target::timg::RegisterBlock,
     _group: PhantomData<TIMG>,
     _timer: PhantomData<INST>,
 }
@@ -55,8 +56,8 @@ pub enum Event {
 
 #[doc(hidden)]
 pub trait TimerGroup: core::ops::Deref {}
-impl TimerGroup for esp32::TIMG0 {}
-impl TimerGroup for esp32::TIMG1 {}
+impl TimerGroup for target::TIMG0 {}
+impl TimerGroup for target::TIMG1 {}
 
 #[doc(hidden)]
 pub trait TimerInst {}
@@ -92,19 +93,19 @@ impl<TIMG: TimerGroup> Timer<TIMG, Timer0> {
     ) {
         let timer0 = Timer::<TIMG, Timer0> {
             clock_control_config,
-            timg: &*timg as *const _ as *const esp32::timg::RegisterBlock,
+            timg: &*timg as *const _ as *const target::timg::RegisterBlock,
             _group: PhantomData {},
             _timer: PhantomData {},
         };
         let timer1 = Timer::<TIMG, Timer1> {
             clock_control_config,
-            timg: &*timg as *const _ as *const esp32::timg::RegisterBlock,
+            timg: &*timg as *const _ as *const target::timg::RegisterBlock,
             _group: PhantomData {},
             _timer: PhantomData {},
         };
         let mut timerlact = Timer::<TIMG, TimerLact> {
             clock_control_config,
-            timg: &*timg as *const _ as *const esp32::timg::RegisterBlock,
+            timg: &*timg as *const _ as *const target::timg::RegisterBlock,
             _group: PhantomData {},
             _timer: PhantomData {},
         };
@@ -131,7 +132,7 @@ impl<INST: TimerInst> Timer<TIMG0, INST> {
         _timer1: Timer<TIMG0, Timer1>,
         _timer2: Timer<TIMG0, TimerLact>,
     ) -> TIMG0 {
-        unsafe { esp32::Peripherals::steal().TIMG0 }
+        unsafe { target::Peripherals::steal().TIMG0 }
     }
 }
 
@@ -143,7 +144,7 @@ impl<INST: TimerInst> Timer<TIMG1, INST> {
         _timer1: Timer<TIMG1, Timer1>,
         _timer2: Timer<TIMG1, TimerLact>,
     ) -> TIMG1 {
-        unsafe { esp32::Peripherals::steal().TIMG1 }
+        unsafe { target::Peripherals::steal().TIMG1 }
     }
 }
 

--- a/src/timer/watchdog.rs
+++ b/src/timer/watchdog.rs
@@ -7,10 +7,11 @@
 use super::Error;
 use super::TimerGroup;
 use crate::prelude::*;
+use crate::target;
+use crate::target::timg::wdtconfig0::WDT_STG0_A;
+use crate::target::timg::wdtconfig0::*;
 use core::marker::PhantomData;
 use embedded_hal::watchdog::{WatchdogDisable, WatchdogEnable};
-use esp32::timg::wdtconfig0::WDT_STG0_A;
-use esp32::timg::wdtconfig0::*;
 
 pub type WatchdogAction = WDT_STG0_A;
 pub type WatchDogResetDuration = WDT_CPU_RESET_LENGTH_A;
@@ -20,7 +21,7 @@ const WATCHDOG_BLOCK_VALUE: u32 = 0x89ABCDEF;
 
 pub struct Watchdog<TIMG: TimerGroup> {
     clock_control_config: super::ClockControlConfig,
-    timg: *const esp32::timg::RegisterBlock,
+    timg: *const target::timg::RegisterBlock,
     _group: PhantomData<TIMG>,
 }
 
@@ -63,13 +64,13 @@ impl<TIMG: TimerGroup> Watchdog<TIMG> {
     pub(crate) fn new(timg: TIMG, clock_control_config: super::ClockControlConfig) -> Self {
         Watchdog {
             clock_control_config,
-            timg: &*timg as *const _ as *const esp32::timg::RegisterBlock,
+            timg: &*timg as *const _ as *const target::timg::RegisterBlock,
             _group: PhantomData,
         }
     }
 
     /// function to unlock the watchdog (write unblock key) and lock after use
-    fn access_registers<A, F: FnMut(&esp32::timg::RegisterBlock) -> A>(&self, mut f: F) -> A {
+    fn access_registers<A, F: FnMut(&target::timg::RegisterBlock) -> A>(&self, mut f: F) -> A {
         // Unprotect write access to registers
 
         let timg = unsafe { &*(self.timg) };


### PR DESCRIPTION
The HAL should ideally re-export the PAC so that users of the library don't have to include both crates. `target` is used instead of `esp32` to match other HALs to make it easier to write cross-platform software.