### PR TITLE
Added SPI peripheral driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ void = { version = "1.0.2", default-features = false }
 
 [dev-dependencies]
 panic-halt = "0.2.0"
+ili9341 = { version = "0.3.0", features = ["graphics"] }
+embedded-graphics = "0.6.2"
 
 [[example]]
 name = "alloc"

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -7,7 +7,7 @@ use esp32_hal::{
     clock_control::sleep,
     dport::Split,
     dprintln,
-    gpio::{Event, Floating, InputPin, OutputPin, Pin, Pull, RTCInputPin, RTCOutputPin},
+    gpio::{Event, Floating, InputPin, Pin, Pull, RTCInputPin},
     interrupt::{Interrupt, InterruptLevel},
     prelude::*,
     serial::{config::Config, Serial},

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -1,0 +1,144 @@
+#![no_std]
+#![no_main]
+
+use core::{fmt::Write, panic::PanicInfo};
+
+use esp32_hal::{
+    clock_control::sleep,
+    dport::Split,
+    dprintln,
+    gpio::{Event, Floating, Pin},
+    interrupt::{Interrupt, InterruptLevel},
+    prelude::*,
+    serial::{config::Config, Serial},
+    target,
+    timer::Timer,
+    Core,
+};
+
+static SERIAL: CriticalSectionSpinLockMutex<
+    Option<
+        esp32_hal::serial::Serial<
+            esp32::UART0,
+            esp32_hal::gpio::Gpio1<esp32_hal::gpio::Unknown>,
+            esp32_hal::gpio::Gpio3<esp32_hal::gpio::Unknown>,
+        >,
+    >,
+> = CriticalSectionSpinLockMutex::new(None);
+
+static GPIO0: CriticalSectionSpinLockMutex<
+    Option<esp32_hal::gpio::Gpio0<esp32_hal::gpio::Input<Floating>>>,
+> = CriticalSectionSpinLockMutex::new(None);
+
+#[entry]
+fn main() -> ! {
+    let dp = target::Peripherals::take().unwrap();
+
+    let (mut dport, dport_clock_control) = dp.DPORT.split();
+
+    let clkcntrl = esp32_hal::clock_control::ClockControl::new(
+        dp.RTCCNTL,
+        dp.APB_CTRL,
+        dport_clock_control,
+        esp32_hal::clock_control::XTAL_FREQUENCY_AUTO,
+    )
+    .unwrap();
+
+    let (clkcntrl_config, mut watchdog_rtc) = clkcntrl.freeze().unwrap();
+    let (_, _, _, mut watchdog0) = Timer::new(dp.TIMG0, clkcntrl_config);
+    let (_, _, _, mut watchdog1) = Timer::new(dp.TIMG1, clkcntrl_config);
+
+    watchdog_rtc.disable();
+    watchdog0.disable();
+    watchdog1.disable();
+
+    let gpios = dp.GPIO.split();
+
+    let mut gpio0 = gpios.gpio0.into_floating_input();
+
+    gpio0.listen_with_options(Event::LowLevel, true, false, true, false, false);
+    interrupt::enable(Interrupt::GPIO_INTR).unwrap();
+
+    // Even though the interrupt is called GPIO_NMI is can be routed to any interrupt level.
+    // Using NMI level (7) is in principle a risk for deadlocks because the
+    // CriticalSectionSpinLockMutex does not disable the NMI. Therefore using level 5 instead.
+
+    // Because the level 5 interrupt clears the interrupt, the regular level 1 handler
+    // will not be called.
+    // Comment out the next line to test the level 1 handler
+    interrupt::enable_with_priority(Core::PRO, Interrupt::GPIO_NMI, InterruptLevel(5)).unwrap();
+
+    // setup serial controller
+    let mut serial: Serial<_, _, _> = Serial::new(
+        dp.UART0,
+        esp32_hal::serial::Pins {
+            tx: gpios.gpio1,
+            rx: gpios.gpio3,
+            cts: None,
+            rts: None,
+        },
+        Config::default().baudrate(115_200.Hz()),
+        clkcntrl_config,
+        &mut dport,
+    )
+    .unwrap();
+
+    writeln!(serial, "\n\nESP32 Started\n\n").unwrap();
+
+    (&SERIAL).lock(|val| *val = Some(serial));
+    (&GPIO0).lock(|val| *val = Some(gpio0));
+
+    let mut x = 0;
+    loop {
+        x = x + 1;
+        (&SERIAL, &GPIO0).lock(|serial, gpio0| {
+            let serial = serial.as_mut().unwrap();
+            let gpio0 = gpio0.as_mut().unwrap();
+            writeln!(serial, "Loop: {} {}", x, gpio0.is_high().unwrap()).unwrap();
+        });
+
+        sleep(500.ms());
+    }
+}
+
+fn handle_gpio_interrupt() {
+    (&GPIO0, &SERIAL).lock(|gpio0, serial| {
+        let gpio0 = gpio0.as_mut().unwrap();
+        let serial = serial.as_mut().unwrap();
+
+        if gpio0.is_non_maskable_interrupt_set() {
+            writeln!(
+                serial,
+                "  Interrupt level: {}, pin state: {}",
+                xtensa_lx6::interrupt::get_level(),
+                gpio0.is_high().unwrap()
+            )
+            .unwrap();
+
+            if gpio0.is_high().unwrap() {
+                gpio0.listen_with_options(Event::LowLevel, true, false, true, false, false);
+            } else {
+                gpio0.listen_with_options(Event::HighLevel, true, false, true, false, false);
+            };
+            // need to change listen before clearing interrupt, otherwise will fire
+            // immediately again.
+            gpio0.clear_interrupt();
+        }
+    });
+}
+
+#[interrupt]
+fn GPIO_INTR() {
+    handle_gpio_interrupt();
+}
+
+#[interrupt]
+fn GPIO_NMI() {
+    handle_gpio_interrupt();
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    dprintln!("\n\n*** {:?}", info);
+    loop {}
+}

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -1,0 +1,224 @@
+//! Example of using the SPI interface using the ESP32 WROVER DEVKIT
+//!
+//! This examples writes to the display. As this pushes many pixels it is quite slow in debug mode,
+//! so please run it in release mode to get an impression of the obtainable speed.
+
+#![no_std]
+#![no_main]
+
+use core::{fmt::Write, panic::PanicInfo};
+
+use esp32_hal::{
+    clock_control::{sleep, ClockControl, XTAL_FREQUENCY_AUTO},
+    dport::Split,
+    dprintln,
+    gpio::{InputPin, OutputPin},
+    prelude::*,
+    serial::{self, Serial},
+    spi::{self, SPI},
+    target,
+    timer::Timer,
+};
+
+use embedded_hal::blocking::spi::WriteIter;
+
+use ili9341;
+
+use embedded_graphics::{
+    fonts::{Font12x16, Text},
+    pixelcolor::Rgb565,
+    prelude::*,
+    primitives::{Circle, Rectangle},
+    style::{PrimitiveStyleBuilder, TextStyle},
+};
+
+// Interface for ili9341 driver
+// ili9341 uses separate command/data pin, this interface set this pin to the appropriate state
+struct SPIInterface<
+    CMD: embedded_hal::digital::v2::OutputPin,
+    SCLK: OutputPin,
+    SDO: OutputPin,
+    SDI: InputPin + OutputPin,
+    CS: OutputPin,
+> {
+    spi: SPI<esp32::SPI2, SCLK, SDO, SDI, CS>,
+    cmd: CMD,
+}
+
+impl<
+        CMD: embedded_hal::digital::v2::OutputPin,
+        SCLK: OutputPin,
+        SDO: OutputPin,
+        SDI: InputPin + OutputPin,
+        CS: OutputPin,
+    > ili9341::Interface for SPIInterface<CMD, SCLK, SDO, SDI, CS>
+{
+    type Error = esp32_hal::spi::Error;
+
+    fn write(&mut self, command: u8, data: &[u8]) -> Result<(), Self::Error> {
+        self.cmd
+            .set_low()
+            .map_err(|_| esp32_hal::spi::Error::PinError)?;
+        self.spi.write(&[command])?;
+        self.cmd
+            .set_high()
+            .map_err(|_| esp32_hal::spi::Error::PinError)?;
+        self.spi.write(data)?;
+        Ok(())
+    }
+
+    fn write_iter(
+        &mut self,
+        command: u8,
+        data: impl IntoIterator<Item = u16>,
+    ) -> Result<(), Self::Error> {
+        self.cmd
+            .set_low()
+            .map_err(|_| esp32_hal::spi::Error::PinError)?;
+        self.spi.write(&[command])?;
+        self.cmd
+            .set_high()
+            .map_err(|_| esp32_hal::spi::Error::PinError)?;
+        self.spi.write_iter(data)?;
+        Ok(())
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    let dp = target::Peripherals::take().expect("Failed to obtain Peripherals");
+
+    let (mut dport, dport_clock_control) = dp.DPORT.split();
+
+    let clkcntrl = ClockControl::new(
+        dp.RTCCNTL,
+        dp.APB_CTRL,
+        dport_clock_control,
+        XTAL_FREQUENCY_AUTO,
+    )
+    .unwrap();
+
+    let (clkcntrl_config, mut watchdog) = clkcntrl.freeze().unwrap();
+    let (_, _, _, mut watchdog0) = Timer::new(dp.TIMG0, clkcntrl_config);
+    let (_, _, _, mut watchdog1) = Timer::new(dp.TIMG1, clkcntrl_config);
+
+    watchdog.disable();
+    watchdog0.disable();
+    watchdog1.disable();
+
+    let _lock = clkcntrl_config.lock_cpu_frequency();
+
+    let pins = dp.GPIO.split();
+
+    let mut serial: Serial<_, _, _> = Serial::new(
+        dp.UART0,
+        serial::Pins {
+            tx: pins.gpio1,
+            rx: pins.gpio3,
+            cts: None,
+            rts: None,
+        },
+        serial::config::Config {
+            baudrate: 115200.Hz(),
+            ..serial::config::Config::default()
+        },
+        clkcntrl_config,
+        &mut dport,
+    )
+    .unwrap();
+
+    // Official ili9341 spec is 10MHz, but overdrive up to 80MHz actually works.
+    // 26MHz chosen here: will be 26MHz when using 26MHz crystal, 20MHz when using 40MHz crystal,
+    // due to integer clock division.
+    // Faster is no use as the cpu is not keeping up with the embedded_graphics library.
+    let spi: SPI<_, _, _, _, _> = SPI::<esp32::SPI2, _, _, _, _>::new(
+        dp.SPI2,
+        spi::Pins {
+            sclk: pins.gpio19,
+            sdo: pins.gpio23,
+            sdi: Some(pins.gpio25),
+            cs: Some(pins.gpio22),
+        },
+        spi::config::Config {
+            baudrate: 26.MHz().into(),
+            bit_order: spi::config::BitOrder::MSBFirst,
+            data_mode: spi::config::MODE_0,
+        },
+        clkcntrl_config,
+        &mut dport,
+    )
+    .unwrap();
+
+    let mut gpio_backlight = pins.gpio5.into_push_pull_output();
+    let mut gpio_reset = pins.gpio18.into_push_pull_output();
+    let gpio_cmd = pins.gpio21.into_push_pull_output();
+
+    gpio_reset.set_low().unwrap();
+    sleep(100.ms());
+    gpio_reset.set_high().unwrap();
+    sleep(100.ms());
+
+    gpio_backlight.set_low().unwrap();
+
+    let spi_if = SPIInterface { spi, cmd: gpio_cmd };
+
+    let mut display =
+        ili9341::Ili9341::new(spi_if, gpio_reset, &mut esp32_hal::delay::Delay::new()).unwrap();
+
+    display
+        .set_orientation(ili9341::Orientation::Landscape)
+        .unwrap();
+
+    Rectangle::new(Point::new(0, 0), Point::new(320, 240))
+        .into_styled(
+            PrimitiveStyleBuilder::new()
+                .fill_color(Rgb565::WHITE)
+                .stroke_width(4)
+                .stroke_color(Rgb565::BLUE)
+                .build(),
+        )
+        .draw(&mut display)
+        .unwrap();
+
+    let rect = Rectangle::new(Point::new(10, 80), Point::new(30, 100)).into_styled(
+        PrimitiveStyleBuilder::new()
+            .fill_color(Rgb565::RED)
+            .stroke_width(1)
+            .stroke_color(Rgb565::WHITE)
+            .build(),
+    );
+
+    let circle = Circle::new(Point::new(20, 50), 10).into_styled(
+        PrimitiveStyleBuilder::new()
+            .fill_color(Rgb565::GREEN)
+            .stroke_width(1)
+            .stroke_color(Rgb565::WHITE)
+            .build(),
+    );
+
+    Text::new("Hello Rust!", Point::new(20, 16))
+        .into_styled(TextStyle::new(Font12x16, Rgb565::RED))
+        .draw(&mut display)
+        .unwrap();
+
+    writeln!(serial, "\n\nESP32 Started\n\n").unwrap();
+
+    loop {
+        for x in (0..280).chain((0..280).rev()) {
+            rect.translate(Point::new(x, 0)).draw(&mut display).unwrap();
+        }
+
+        for x in (0..280).chain((0..280).rev()) {
+            circle
+                .translate(Point::new(x, 0))
+                .draw(&mut display)
+                .unwrap();
+        }
+    }
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    dprintln!("\n\n*** {:?}", info);
+    loop {}
+}

--- a/flash
+++ b/flash
@@ -243,7 +243,18 @@ then
         then
             printf "\n\n"
             # get gen_esp32part.py and create binary partition table
-            curl -s -S -L $GENPART_SOURCE --output target/gen_esp32part.py
+            curl -s -S -f --max-time 2 -L $GENPART_SOURCE --output target/gen_esp32part.py_new
+
+            if [ $? -ne 0 ]; then
+                if [ -f target/gen_esp32part.py ]; then
+                    printf "\n${ERROR}Failed to get gen_esp32part.py${RESET} using old one\n\n"
+                else
+                    printf "\n${ERROR}Failed to get gen_esp32part.py${RESET}\n\n"
+                    exit 1
+                fi
+            else 
+                mv target/gen_esp32part.py_new target/gen_esp32part.py
+            fi
             
             rm target/partitions.bin 2> /dev/null
             python target/gen_esp32part.py partitions.csv target/partitions.bin
@@ -254,9 +265,23 @@ then
         fi
 
 
+        printf "${STAGE}Getting bootloader... ${RESET}"
+
         # get bootloader.bin file 
         # (different variants exist, but only difference is flash settings which are overriden by esptool)
-        curl -s -S -L $BOOTLOADER_SOURCE --output target/bootloader.bin
+        curl -s -S -f --max-time 2 -L $BOOTLOADER_SOURCE --output target/bootloader.bin_new 
+
+        if [ $? -ne 0 ]; then
+            if [ -f target/bootloader.bin ]; then
+                printf "\n${ERROR}Failed to get bootloader${RESET} using old one\n\n"
+            else
+                printf "\n${ERROR}Failed to get bootloader${RESET}\n\n"
+                exit 1
+            fi
+        else 
+            mv target/bootloader.bin_new target/bootloader.bin
+            printf "succesfully downloader bootloader\n\n"
+        fi
 
         # check if bootloader.bin and paritions.bin are already correctly flashed (to prevent unnecessary writes)
         printf "${STAGE}Verify bootloader and partition table...${RESET} "

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,0 +1,30 @@
+//! Implementation of embedded hal delay traits using busy waiting
+use crate::units::{MicroSeconds, MilliSeconds};
+use embedded_hal::blocking::delay::{DelayMs, DelayUs};
+
+#[derive(Clone)]
+pub struct Delay {}
+
+impl Delay {
+    pub fn new() -> Delay {
+        Delay {}
+    }
+}
+
+/// Delay in ms
+///
+/// *Note: Maximum duration is 2e32-1 ns ~ 4.29s *
+impl<UXX: Into<u32>> DelayMs<UXX> for Delay {
+    fn delay_ms(&mut self, ms: UXX) {
+        crate::clock_control::sleep(MilliSeconds(ms.into()))
+    }
+}
+
+/// Delay in us
+///
+/// *Note: Maximum duration is 2e32-1 ns ~ 4.29s *
+impl<UXX: Into<u32>> DelayUs<UXX> for Delay {
+    fn delay_us(&mut self, us: UXX) {
+        crate::clock_control::sleep(MicroSeconds(us.into()))
+    }
+}

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -860,7 +860,16 @@ macro_rules! impl_analog {
 
                 #[inline(always)]
                 fn disable_analog(&self) {
-                    unsafe{ &*RTCIO::ptr() }.$pin_reg.modify(|_,w| w.$mux_sel().clear_bit());
+                    let rtcio = unsafe{ &*RTCIO::ptr() };
+
+                    rtcio.$pin_reg.modify(|_,w| w.$mux_sel().clear_bit());
+
+                    $(
+                        rtcio.$pin_reg.modify(|_,w| {
+                            w.$rue().clear_bit().$rde().clear_bit()
+                        });
+                    )?
+
                 }
             }
 

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -1,7 +1,6 @@
 //! GPIO and pin configuration
 //!
 //! # TODO:
-//! - Address errata 3.6: pull up/down can only be controlled via RT_GPIO
 //! - Maybe address errata 3.14: missing edge triggered GPIO interrupts
 //! - Implement interrupt functionality
 //! - Extend RTC functionality
@@ -67,8 +66,16 @@ pub trait InputPin: Pin {
     ) -> &mut Self;
 }
 
+pub trait Pull {
+    /// Enable/Disable internal pull up resistor
+    fn internal_pull_up(&mut self, on: bool) -> &mut Self;
+
+    /// Enable/Disable internal pull down resistor
+    fn internal_pull_down(&mut self, on: bool) -> &mut Self;
+}
+
 /// Functions available on output pins
-pub trait OutputPin: Pin {
+pub trait OutputPin: Pin + Pull {
     /// Set pad to open drain output
     ///
     /// Disables input, pull up/down resistors and sleep mode.
@@ -94,12 +101,6 @@ pub trait OutputPin: Pin {
 
     /// Enable/Disable open drain
     fn enable_open_drain(&mut self, on: bool) -> &mut Self;
-
-    /// Enable/Disable internal pull up resistor
-    fn internal_pull_up(&mut self, on: bool) -> &mut Self;
-
-    /// Enable/Disable internal pull down resistor
-    fn internal_pull_down(&mut self, on: bool) -> &mut Self;
 
     /// Enable/disable the output while in sleep mode
     fn enable_output_in_sleep_mode(&mut self, on: bool) -> &mut Self;
@@ -353,6 +354,7 @@ macro_rules! impl_output {
         }
 
         impl<MODE> OutputPin for $pxi<MODE> {
+
             fn set_to_open_drain_output(&mut self) -> &mut Self {
                 self.init_output(AlternateFunction::Function3, true);
                 self
@@ -396,20 +398,6 @@ macro_rules! impl_output {
 
             fn enable_open_drain(&mut self, on: bool) -> &mut Self {
                 unsafe { &*GPIO::ptr() }.pin[$pin_num].modify(|_, w| w.pad_driver().bit(on));
-                self
-            }
-
-            fn internal_pull_up(&mut self, on: bool) -> &mut Self {
-                unsafe { &*IO_MUX::ptr() }
-                    .$iomux
-                    .modify(|_, w| w.fun_wpu().bit(on));
-                self
-            }
-
-            fn internal_pull_down(&mut self, on: bool) -> &mut Self {
-                unsafe { &*IO_MUX::ptr() }
-                    .$iomux
-                    .modify(|_, w| w.fun_wpd().bit(on));
                 self
             }
 
@@ -651,13 +639,47 @@ macro_rules! impl_output_wrap {
             ($pin_num, $pin_num % 32, $iomux, enable1_w1ts, enable1_w1tc, out1_w1ts, out1_w1tc)
             $( ,( $( $af_output_signal: $af_output ),* ) )? );
     };
-    ($pxi:ident, $pin_num:expr, $bank:ident, $iomux:ident, $TYPE:ident) => {
+    ($pxi:ident, $pin_num:expr, $bank:ident, $iomux:ident, Input) => {
         // Output not implemented for this pin
     };
 }
 
+macro_rules! impl_rtc_wrap {
+    ($pxi:ident, $pin_num:expr, $bank:ident, $iomux:ident, IO) => {
+        impl<MODE> Pull for $pxi<MODE> {
+            fn internal_pull_up(&mut self, on: bool) -> &mut Self {
+                unsafe { &*IO_MUX::ptr() }
+                    .$iomux
+                    .modify(|_, w| w.fun_wpu().bit(on));
+                self
+            }
+
+            fn internal_pull_down(&mut self, on: bool) -> &mut Self {
+                unsafe { &*IO_MUX::ptr() }
+                    .$iomux
+                    .modify(|_, w| w.fun_wpd().bit(on));
+                self
+            }
+        }
+
+        impl<MODE> $pxi<MODE> {
+            #[inline(always)]
+            fn disable_analog(&self) {
+                // No analog functionality on this pin, so nothing to do, function is implemented
+                // for convenience so it can be called on any GPIO pin
+            }
+        }
+    };
+    ($pxi:ident, $pin_num:expr, $bank:ident, $iomux:ident, IO, RTC) => {
+        // Pull up/down controlled via RTC mux (to address errata 3.6)
+    };
+    ($pxi:ident, $pin_num:expr, $bank:ident, $iomux:ident, Input, RTC) => {
+        // Output not implemented for this pin, so pull up/down not available
+    };
+}
+
 macro_rules! gpio {
-    ( $($pxi:ident: ($pname:ident, $bank:ident, $pin_num:literal, $iomux:ident, $type:ident),
+    ( $($pxi:ident: ($pname:ident, $bank:ident, $pin_num:literal, $iomux:ident, $type:ident $(, $rtc:ident)? ),
         $(
             ( $( $af_input_signal:ident: $af_input:ident ),* ),
             $(
@@ -698,7 +720,8 @@ macro_rules! gpio {
                 $( ,( $( $af_input_signal: $af_input ),* ) )? );
             impl_output_wrap!($pxi, $pin_num, $bank, $iomux, $type
                 $($( ,( $( $af_output_signal: $af_output ),* ) )? )? );
-        )+
+                impl_rtc_wrap!($pxi, $pin_num, $bank, $iomux, $type $(, $rtc)?);
+            )+
     };
 }
 
@@ -706,19 +729,19 @@ macro_rules! gpio {
 // TODO these pins have a reset mode of 0 (apart from Gpio27),
 // input disable, does that mean they are actually in output mode on reset?
 gpio! {
-    Gpio0:  (gpio0,  Bank0, 0,  gpio0, IO),
+    Gpio0:  (gpio0,  Bank0, 0,  gpio0, IO, RTC),
         (EMAC_TX_CLK: Function6),
         (CLK_OUT1: Function2),
     Gpio1:  (gpio1,  Bank0, 1,  u0txd, IO),
         (EMAC_RXD2: Function6),
         (U0TXD: Function1, CLK_OUT3: Function2),
-    Gpio2:  (gpio2,  Bank0, 2,  gpio2, IO),
+    Gpio2:  (gpio2,  Bank0, 2,  gpio2, IO, RTC),
         (HSPIWP: Function2, HS2_DATA0: Function4, SD_DATA0: Function5),
         (HS2_DATA0: Function4, SD_DATA0: Function5),
     Gpio3:  (gpio3,  Bank0, 3,  u0rxd, IO),
         (U0RXD: Function1),
         (CLK_OUT2: Function2),
-    Gpio4:  (gpio4,  Bank0, 4,  gpio4, IO),
+    Gpio4:  (gpio4,  Bank0, 4,  gpio4, IO, RTC),
         (HSPIHD: Function2, HS2_DATA1: Function4, SD_DATA1: Function5, EMAC_TX_ER: Function6),
         (HS2_DATA1: Function4, SD_DATA1: Function5),
     Gpio5:  (gpio5,  Bank0, 5,  gpio5, IO),
@@ -742,16 +765,16 @@ gpio! {
     Gpio11: (gpio11, Bank0, 11, sd_cmd, IO),
         (SPICS0: Function2),
         (SD_CMD: Function1, SPICS0: Function2, HS1_CMD: Function4, U1RTS: Function5),
-    Gpio12: (gpio12, Bank0, 12, mtdi, IO),
+    Gpio12: (gpio12, Bank0, 12, mtdi, IO, RTC),
         (MTDI: Function1, HSPIQ: Function2, HS2_DATA2: Function4, SD_DATA2: Function5),
         (HSPIQ: Function2, HS2_DATA2: Function4, SD_DATA2: Function5, EMAC_TXD3: Function6),
-    Gpio13: (gpio13, Bank0, 13, mtck, IO),
+    Gpio13: (gpio13, Bank0, 13, mtck, IO, RTC),
         (MTCK: Function1, HSPID: Function2, HS2_DATA3: Function4, SD_DATA3: Function5),
         (HSPID: Function2, HS2_DATA3: Function4, SD_DATA3: Function5, EMAC_RX_ER: Function6),
-    Gpio14: (gpio14, Bank0, 14, mtms, IO),
+    Gpio14: (gpio14, Bank0, 14, mtms, IO, RTC),
         (MTMS: Function1, HSPICLK: Function2),
         (HSPICLK: Function2, HS2_CLK: Function4, SD_CLK: Function5, EMAC_TXD2: Function6),
-    Gpio15: (gpio15, Bank0, 15, mtdo, IO),
+    Gpio15: (gpio15, Bank0, 15, mtdo, IO, RTC),
         (HSPICS0: Function2, EMAC_RXD3: Function6),
         (MTDO: Function1, HSPICS0: Function2, HS2_CMD: Function4, SD_CMD: Function5),
     Gpio16: (gpio16, Bank0, 16, gpio16, IO),
@@ -776,39 +799,24 @@ gpio! {
     Gpio23: (gpio23, Bank0, 23, gpio23, IO),
         (VSPID: Function2),
         (VSPID: Function2, HS1_STROBE: Function4),
-    Gpio25: (gpio25, Bank0, 25, gpio25, IO),
+    Gpio25: (gpio25, Bank0, 25, gpio25, IO, RTC),
         (EMAC_RXD0: Function6),
         (),
-    Gpio26: (gpio26, Bank0, 26, gpio26, IO),
+    Gpio26: (gpio26, Bank0, 26, gpio26, IO, RTC),
         (EMAC_RXD1: Function6),
         (),
-    Gpio27: (gpio27, Bank0, 27, gpio27, IO),
+    Gpio27: (gpio27, Bank0, 27, gpio27, IO, RTC),
         (EMAC_RX_DV: Function6),
         (),
 
-    Gpio32: (gpio32, Bank1, 32, gpio32, IO),
-    Gpio33: (gpio33, Bank1, 33, gpio33, IO),
-    Gpio34: (gpio34, Bank1, 34, gpio34, Input),
-    Gpio35: (gpio35, Bank1, 35, gpio35, Input),
-    Gpio36: (gpio36, Bank1, 36, gpio36, Input),
-    Gpio37: (gpio37, Bank1, 37, gpio37, Input),
-    Gpio38: (gpio38, Bank1, 38, gpio38, Input),
-    Gpio39: (gpio39, Bank1, 39, gpio39, Input),
-}
-
-macro_rules! impl_no_analog {
-    ([
-        $($pxi:ident),+
-    ]) => {
-        $(
-            impl<MODE> $pxi<MODE> {
-                #[inline(always)]
-                fn disable_analog(&self) {
-                    /* No analog functionality on this pin, so nothing to do */
-                }
-            }
-        )+
-    };
+    Gpio32: (gpio32, Bank1, 32, gpio32, IO, RTC),
+    Gpio33: (gpio33, Bank1, 33, gpio33, IO, RTC),
+    Gpio34: (gpio34, Bank1, 34, gpio34, Input, RTC),
+    Gpio35: (gpio35, Bank1, 35, gpio35, Input, RTC),
+    Gpio36: (gpio36, Bank1, 36, gpio36, Input, RTC),
+    Gpio37: (gpio37, Bank1, 37, gpio37, Input, RTC),
+    Gpio38: (gpio38, Bank1, 38, gpio38, Input, RTC),
+    Gpio39: (gpio39, Bank1, 39, gpio39, Input, RTC),
 }
 
 macro_rules! impl_analog {
@@ -843,8 +851,7 @@ macro_rules! impl_analog {
                     // Disable pull-up and pull-down resistors on the pin, if it has them
                     $(
                         rtcio.$pin_reg.modify(|_,w| {
-                            w.$rue().clear_bit();
-                            w.$rde().clear_bit()
+                            w.$rue().clear_bit().$rde().clear_bit()
                         });
                     )?
 
@@ -853,18 +860,33 @@ macro_rules! impl_analog {
 
                 #[inline(always)]
                 fn disable_analog(&self) {
-                    let rtcio = unsafe{ &*RTCIO::ptr() };
-                    rtcio.$pin_reg.modify(|_,w| w.$mux_sel().clear_bit());
+                    unsafe{ &*RTCIO::ptr() }.$pin_reg.modify(|_,w| w.$mux_sel().clear_bit());
                 }
             }
+
+            $(
+                // addresses errata 3.6: pull up/down on pins with RTC can be only controlled
+                // via RTC_MUX
+                impl<MODE> Pull for $pxi<MODE> {
+                    fn internal_pull_up(&mut self, on: bool) -> &mut Self {
+                        unsafe{ &*RTCIO::ptr() }.$pin_reg.modify(|_,w| {
+                            w.$rue().bit(on)
+                        });
+                        self
+                    }
+
+                    fn internal_pull_down(&mut self, on: bool) -> &mut Self {
+                        unsafe{ &*RTCIO::ptr() }.$pin_reg.modify(|_,w| {
+                            w.$rde().bit(on)
+                        });
+                        self
+                    }
+                }
+            )?
+
         )+
     }
 }
-
-impl_no_analog! {[
-    Gpio1, Gpio3, Gpio5, Gpio6, Gpio7, Gpio8, Gpio9, Gpio10, Gpio11,
-    Gpio16, Gpio17, Gpio18, Gpio19, Gpio20, Gpio21, Gpio22, Gpio23
-]}
 
 impl_analog! {[
     Gpio36: (0, sensor_pads, sense1_mux_sel, sense1_fun_sel, sense1_fun_ie,),

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -1,9 +1,5 @@
 //! GPIO and pin configuration
 //!
-//! # TODO:
-//! - Maybe address errata 3.14: missing edge triggered GPIO interrupts
-//! - Implement interrupt functionality
-//! - Extend RTC functionality
 
 use {
     crate::target::{GPIO, IO_MUX, RTCIO},
@@ -13,6 +9,7 @@ use {
 };
 
 mod mux;
+pub use crate::prelude::*;
 pub use mux::*;
 
 /// Extension trait to split a GPIO peripheral into independent pins and registers
@@ -61,6 +58,8 @@ pub trait Pin {
     /// This function overwrites any previous settings, so if any of the boolean are set to false
     /// the interrupt of that type and to that core are disabled.
     ///
+    /// *Note: Edge triggering is not supported for wake-up
+    ///
     /// *Note: Even though the interrupt is called NMI it can be routed to any level via the
     /// [interrupt::enable_with_priority][crate::interrupt::enable_with_priority] function.*
     ///
@@ -89,6 +88,9 @@ pub trait Pin {
 
     /// Check if the non maskable interrupt for this pin is set for the current core
     fn is_non_maskable_interrupt_set(&mut self) -> bool;
+
+    /// Enable/Disable holding of the pads current state even through reset or deep sleep
+    fn enable_hold(&mut self, on: bool);
 }
 
 /// Functions available on input pins
@@ -104,6 +106,9 @@ pub trait InputPin: Pin {
 
     /// Enable/Disable input circuitry while in sleep mode
     fn enable_input_in_sleep_mode(&mut self, on: bool) -> &mut Self;
+
+    /// Get state of input
+    fn is_input_high(&mut self) -> bool;
 
     /// Connect input to peripheral using default options
     ///
@@ -205,6 +210,39 @@ pub trait OutputPin: Pin + Pull {
     ) -> &mut Self;
 }
 
+/// Functions available on RTC input pins
+pub trait RTCInputPin {
+    /// Enable/Disable the sleep mode of the RTC pad
+    fn rtc_sleep_mode(&mut self, on: bool) -> &mut Self;
+
+    /// Enable/Disable RTC input circuitry
+    fn rtc_enable_input(&mut self, on: bool) -> &mut Self;
+
+    /// Enable/Disable RTC input circuitry while in sleep mode
+    fn rtc_enable_input_in_sleep_mode(&mut self, on: bool) -> &mut Self;
+
+    /// Get state of RTC input
+    fn rtc_is_input_high(&mut self) -> bool;
+}
+
+/// Functions available on RTC output pins
+pub trait RTCOutputPin {
+    /// Enable/disable the RTC output
+    fn rtc_enable_output(&mut self, on: bool) -> &mut Self;
+
+    /// Set the RTC output to high or low
+    fn rtc_set_output_high(&mut self, on: bool) -> &mut Self;
+
+    /// Set RTC drive strength
+    fn rtc_set_drive_strength(&mut self, strength: DriveStrength) -> &mut Self;
+
+    /// Enable/Disable RTC open drain
+    fn rtc_enable_open_drain(&mut self, on: bool) -> &mut Self;
+
+    /// Enable/disable the RTC output while in sleep mode
+    fn rtc_enable_output_in_sleep_mode(&mut self, on: bool) -> &mut Self;
+}
+
 /// Interrupt events
 ///
 /// *Note: ESP32 has a bug (3.14), which prevents correct triggering of interrupts when
@@ -213,6 +251,7 @@ pub trait OutputPin: Pin + Pull {
 /// GPIO with edge triggering on the CPU.*
 //
 // Value must correspond to values in the register
+#[derive(Copy, Clone)]
 pub enum Event {
     /// Trigger on the rising edge
     RisingEdge = 1,
@@ -234,6 +273,11 @@ pub struct Input<MODE> {
     _mode: PhantomData<MODE>,
 }
 
+/// Input mode via RTC (type state)
+pub struct RTCInput<MODE> {
+    _mode: PhantomData<MODE>,
+}
+
 /// Floating input (type state)
 pub struct Floating;
 
@@ -245,6 +289,11 @@ pub struct PullUp;
 
 /// Output mode (type state)
 pub struct Output<MODE> {
+    _mode: PhantomData<MODE>,
+}
+
+/// Output mode via RTC (type state)
+pub struct RTCOutput<MODE> {
     _mode: PhantomData<MODE>,
 }
 
@@ -630,6 +679,10 @@ macro_rules! impl_input {
                 self
             }
 
+            fn is_input_high(&mut self) -> bool {
+                unsafe { &*GPIO::ptr() }.$reg.read().$reader().bits() & (1 << $bit) != 0
+            }
+
             fn connect_input_to_peripheral_with_options(
                 &mut self,
                 signal: InputSignal,
@@ -689,6 +742,14 @@ macro_rules! impl_input {
                 pro_int: bool, app_int: bool, pro_nmi: bool, app_nmi: bool,
                 wake_up_from_light_sleep: bool
             ) {
+                if wake_up_from_light_sleep {
+                    match event {
+                        Event::AnyEdge | Event::RisingEdge | Event::FallingEdge => {
+                            panic!("Edge triggering is not supported for wake-up from light sleep");
+                        },
+                        _ => {}
+                    }
+                }
                 unsafe {
                     (&*GPIO::ptr()).pin[$pin_num].modify(|_, w|
                         w
@@ -698,12 +759,14 @@ macro_rules! impl_input {
                             .wakeup_enable().bit(wake_up_from_light_sleep)
                     );
                 }
+                self.rtc_enable_wake_up_from_light_sleep(event, wake_up_from_light_sleep);
             }
 
             fn unlisten(&mut self) {
                 unsafe { (&*GPIO::ptr()).pin[$pin_num].modify(|_, w|
                     w.int_ena().bits(0).int_type().bits(0).int_ena().bits(0) );
                 }
+                self.rtc_enable_wake_up_from_light_sleep(Event::HighLevel, false);
             }
 
             fn clear_interrupt(&mut self) {
@@ -728,11 +791,15 @@ macro_rules! impl_input {
                         (unsafe {&*GPIO::ptr()}.$acpu_nmi.read().bits() & (1 << $bit)) !=0,
                 }
             }
+
+            fn enable_hold(&mut self, on: bool) {
+                self.enable_hold_internal(on)
+            }
         }
     };
 }
 
-macro_rules! impl_input_wrap {
+macro_rules! impl_pin_wrap {
     ($pxi:ident, $pin_num:expr, Bank0, $iomux:ident, $TYPE:ident
         $( ,( $( $af_input_signal:ident : $af_input:ident ),* ) )?
     ) => {
@@ -770,8 +837,16 @@ macro_rules! impl_output_wrap {
     };
 }
 
-macro_rules! impl_rtc_wrap {
-    ($pxi:ident, $pin_num:expr, $bank:ident, $iomux:ident, IO) => {
+static RTCIO_LOCK: CriticalSectionSpinLockMutex<()> = CriticalSectionSpinLockMutex::new(());
+
+macro_rules! impl_no_rtc {
+    ($pxi:ident, $pin_num:expr, $bank:ident, $iomux:ident, IO, RTC) => {
+        // Pull up/down controlled via RTC mux (to address errata 3.6)
+    };
+    ($pxi:ident, $pin_num:expr, $bank:ident, $iomux:ident, Input, RTC) => {
+        // Output not implemented for this pin, so pull up/down not available
+    };
+    ($pxi:ident, $pin_num:expr, $bank:ident, $iomux:ident, IO, $hold_bit:expr) => {
         impl<MODE> Pull for $pxi<MODE> {
             fn internal_pull_up(&mut self, on: bool) -> &mut Self {
                 unsafe { &*IO_MUX::ptr() }
@@ -790,22 +865,32 @@ macro_rules! impl_rtc_wrap {
 
         impl<MODE> $pxi<MODE> {
             #[inline(always)]
-            fn disable_analog(&self) {
-                // No analog functionality on this pin, so nothing to do, function is implemented
-                // for convenience so it can be called on any GPIO pin
+
+            // No analog functionality on this pin, so nothing to do, function is implemented
+            // for convenience so it can be called on any GPIO pin
+            fn disable_analog(&self) {}
+
+            // No rtc functionality on this pin, so nothing to do, function is implemented
+            // for convenience so it can be called on any GPIO pin
+            #[inline(always)]
+            fn rtc_enable_wake_up_from_light_sleep(&self, _event: Event, _enable: bool) {}
+
+            #[inline(always)]
+            fn enable_hold_internal(&self, on: bool) {
+                (&RTCIO_LOCK).lock(|_| unsafe {
+                    // shared register without set/clear functionality, so needs lock
+                    (&*RTCIO::ptr()).dig_pad_hold.modify(|r, w| {
+                        w.bits(r.bits() & !((on as u32) << $hold_bit) | ((on as u32) << $hold_bit))
+                    })
+                });
             }
         }
-    };
-    ($pxi:ident, $pin_num:expr, $bank:ident, $iomux:ident, IO, RTC) => {
-        // Pull up/down controlled via RTC mux (to address errata 3.6)
-    };
-    ($pxi:ident, $pin_num:expr, $bank:ident, $iomux:ident, Input, RTC) => {
-        // Output not implemented for this pin, so pull up/down not available
     };
 }
 
 macro_rules! gpio {
-    ( $($pxi:ident: ($pname:ident, $bank:ident, $pin_num:literal, $iomux:ident, $type:ident $(, $rtc:ident)? ),
+    ( $($pxi:ident: ($pname:ident, $bank:ident, $pin_num:literal, $iomux:ident,
+        $type:ident, $rtc:tt ),
         $(
             ( $( $af_input_signal:ident: $af_input:ident ),* ),
             $(
@@ -842,12 +927,12 @@ macro_rules! gpio {
                 _mode: PhantomData<MODE>,
             }
 
-            impl_input_wrap!($pxi, $pin_num, $bank, $iomux, $type
+            impl_pin_wrap!($pxi, $pin_num, $bank, $iomux, $type
                 $( ,( $( $af_input_signal: $af_input ),* ) )? );
             impl_output_wrap!($pxi, $pin_num, $bank, $iomux, $type
                 $($( ,( $( $af_output_signal: $af_output ),* ) )? )? );
-                impl_rtc_wrap!($pxi, $pin_num, $bank, $iomux, $type $(, $rtc)?);
-            )+
+            impl_no_rtc!($pxi, $pin_num, $bank, $iomux, $type, $rtc);
+        )+
     };
 }
 
@@ -858,37 +943,37 @@ gpio! {
     Gpio0:  (gpio0,  Bank0, 0,  gpio0, IO, RTC),
         (EMAC_TX_CLK: Function6),
         (CLK_OUT1: Function2),
-    Gpio1:  (gpio1,  Bank0, 1,  u0txd, IO),
+    Gpio1:  (gpio1,  Bank0, 1,  u0txd, IO, 0),
         (EMAC_RXD2: Function6),
         (U0TXD: Function1, CLK_OUT3: Function2),
     Gpio2:  (gpio2,  Bank0, 2,  gpio2, IO, RTC),
         (HSPIWP: Function2, HS2_DATA0: Function4, SD_DATA0: Function5),
         (HS2_DATA0: Function4, SD_DATA0: Function5),
-    Gpio3:  (gpio3,  Bank0, 3,  u0rxd, IO),
+    Gpio3:  (gpio3,  Bank0, 3,  u0rxd, IO, 1),
         (U0RXD: Function1),
         (CLK_OUT2: Function2),
     Gpio4:  (gpio4,  Bank0, 4,  gpio4, IO, RTC),
         (HSPIHD: Function2, HS2_DATA1: Function4, SD_DATA1: Function5, EMAC_TX_ER: Function6),
         (HS2_DATA1: Function4, SD_DATA1: Function5),
-    Gpio5:  (gpio5,  Bank0, 5,  gpio5, IO),
+    Gpio5:  (gpio5,  Bank0, 5,  gpio5, IO, 8),
         (VSPICS0: Function2, HS1_DATA6: Function4, EMAC_RX_CLK: Function6),
         (HS1_DATA6: Function4),
-    Gpio6:  (gpio6,  Bank0, 6,  sd_clk, IO),
+    Gpio6:  (gpio6,  Bank0, 6,  sd_clk, IO, 2),
         (U1CTS: Function5),
         (SD_CLK: Function1, SPICLK: Function2, HS1_CLK: Function4),
-    Gpio7:  (gpio7,  Bank0, 7,  sd_data0, IO),
+    Gpio7:  (gpio7,  Bank0, 7,  sd_data0, IO, 3),
         (SD_DATA0: Function1, SPIQ: Function2, HS1_DATA0: Function4),
         (SD_DATA0: Function1, SPIQ: Function2, HS1_DATA0: Function4, U2RTS: Function5),
-    Gpio8:  (gpio8,  Bank0, 8,  sd_data1, IO),
+    Gpio8:  (gpio8,  Bank0, 8,  sd_data1, IO, 4),
         (SD_DATA1: Function1, SPID: Function2, HS1_DATA1: Function4, U2CTS: Function5),
         (SD_DATA1: Function1, SPID: Function2, HS1_DATA1: Function4),
-    Gpio9:  (gpio9,  Bank0, 9,  sd_data2, IO),
+    Gpio9:  (gpio9,  Bank0, 9,  sd_data2, IO, 5),
         (SD_DATA2: Function1, SPIHD: Function2, HS1_DATA2: Function4, U1RXD: Function5),
         (SD_DATA2: Function1, SPIHD: Function2, HS1_DATA2: Function4),
-    Gpio10: (gpio10, Bank0, 10, sd_data3, IO),
+    Gpio10: (gpio10, Bank0, 10, sd_data3, IO, 6),
         (SD_DATA3: Function1, SPIWP: Function2, HS1_DATA3: Function4),
         (SD_DATA3: Function1, SPIWP: Function2, HS1_DATA3: Function4, U1TXD: Function5),
-    Gpio11: (gpio11, Bank0, 11, sd_cmd, IO),
+    Gpio11: (gpio11, Bank0, 11, sd_cmd, IO, 7),
         (SPICS0: Function2),
         (SD_CMD: Function1, SPICS0: Function2, HS1_CMD: Function4, U1RTS: Function5),
     Gpio12: (gpio12, Bank0, 12, mtdi, IO, RTC),
@@ -903,26 +988,26 @@ gpio! {
     Gpio15: (gpio15, Bank0, 15, mtdo, IO, RTC),
         (HSPICS0: Function2, EMAC_RXD3: Function6),
         (MTDO: Function1, HSPICS0: Function2, HS2_CMD: Function4, SD_CMD: Function5),
-    Gpio16: (gpio16, Bank0, 16, gpio16, IO),
+    Gpio16: (gpio16, Bank0, 16, gpio16, IO, 9),
         (HS1_DATA4: Function4, U2RXD: Function5),
         (HS1_DATA4: Function4, EMAC_CLK_OUT: Function6),
-    Gpio17: (gpio17, Bank0, 17, gpio17, IO),
+    Gpio17: (gpio17, Bank0, 17, gpio17, IO, 10),
         (HS1_DATA5: Function4),
         (HS1_DATA5: Function4, U2TXD: Function5, EMAC_CLK_180: Function6),
-    Gpio18: (gpio18, Bank0, 18, gpio18, IO),
+    Gpio18: (gpio18, Bank0, 18, gpio18, IO, 11),
         (VSPICLK: Function2, HS1_DATA7: Function4),
         (VSPICLK: Function2, HS1_DATA7: Function4),
-    Gpio19: (gpio19, Bank0, 19, gpio19, IO),
+    Gpio19: (gpio19, Bank0, 19, gpio19, IO, 12),
         (VSPIQ: Function2, U0CTS: Function4),
         (VSPIQ: Function2, EMAC_TXD0: Function6),
-    Gpio20: (gpio20, Bank0, 20, gpio20, IO), // pin logic present, but no external pad
-    Gpio21: (gpio21, Bank0, 21, gpio21, IO),
+    Gpio20: (gpio20, Bank0, 20, gpio20, IO, 13), // pin logic present, but no external pad
+    Gpio21: (gpio21, Bank0, 21, gpio21, IO, 14),
         (VSPIHD: Function2),
         (VSPIHD: Function2, EMAC_TX_EN: Function6),
-    Gpio22: (gpio22, Bank0, 22, gpio22, IO),
+    Gpio22: (gpio22, Bank0, 22, gpio22, IO, 15),
         (VSPIWP: Function2),
         (VSPIWP: Function2, U0RTS: Function4, EMAC_TXD1: Function6),
-    Gpio23: (gpio23, Bank0, 23, gpio23, IO),
+    Gpio23: (gpio23, Bank0, 23, gpio23, IO, 16),
         (VSPID: Function2),
         (VSPID: Function2, HS1_STROBE: Function4),
     Gpio25: (gpio25, Bank0, 25, gpio25, IO, RTC),
@@ -947,55 +1032,246 @@ gpio! {
 
 macro_rules! impl_analog {
     ([
-        $($pxi:ident: ($pin_num:expr, $pin_reg:ident, $mux_sel:ident, $fun_select:ident,
-          $in_enable:ident, $($rue:ident, $rde:ident)?),)+
+        $($pxi:ident: ($pin_num:expr, $pin_reg:ident, $hold: ident, $mux_sel:ident,
+            $fun_sel:ident, $fun_ie:ident, $slp_ie:ident, $slp_sel:ident
+            $(, $rue:ident, $rde:ident, $drv:ident, $slp_oe:ident)?),)+
     ]) => {
         $(
+            impl<MODE> embedded_hal::digital::v2::InputPin for $pxi<RTCInput<MODE>> {
+                type Error = Infallible;
+
+                fn is_high(&self) -> Result<bool, Self::Error> {
+                    // NOTE(unsafe) atomic read to a stateless register
+                    Ok(unsafe{&*RTCIO::ptr()}.in_.read().in_next().bits() & (1 << $pin_num) != 0)
+                }
+
+                fn is_low(&self) -> Result<bool, Self::Error> {
+                    Ok(!self.is_high()?)
+                }
+            }
+
+            impl<MODE> RTCInputPin for $pxi<MODE> {
+                fn rtc_sleep_mode(&mut self, on: bool) -> &mut Self {
+                    // shared register without set/clear functionality, so needs lock
+                    (&RTCIO_LOCK).lock(|_|
+                        unsafe{ &*RTCIO::ptr() }.$pin_reg.modify(|_,w| w.$slp_sel().bit(on))
+                    );
+                    self
+                }
+
+                fn rtc_enable_input(&mut self, on: bool) -> &mut Self {
+                    // shared register without set/clear functionality, so needs lock
+                    (&RTCIO_LOCK).lock(|_|
+                        unsafe{ &*RTCIO::ptr() }.$pin_reg.modify(|_,w| w.$fun_ie().bit(on))
+                    );
+                    self
+                }
+
+                fn rtc_enable_input_in_sleep_mode(&mut self, on: bool) -> &mut Self {
+                    // shared register without set/clear functionality, so needs lock
+                    (&RTCIO_LOCK).lock(|_|
+                        unsafe{ &*RTCIO::ptr() }.$pin_reg.modify(|_,w| w.$slp_ie().bit(on))
+                    );
+                    self
+                }
+
+                fn rtc_is_input_high(&mut self) -> bool {
+                    unsafe{&*RTCIO::ptr()}.in_.read().in_next().bits() & (1 << $pin_num) != 0
+                }
+            }
+
+            $(
+                impl<MODE> embedded_hal::digital::v2::OutputPin for $pxi<RTCOutput<MODE>> {
+                    type Error = Infallible;
+
+                    fn set_high(&mut self) -> Result<(), Self::Error> {
+                        self.rtc_set_output_high(true);
+                        Ok(())
+                    }
+
+                    fn set_low(&mut self) -> Result<(), Self::Error> {
+                        self.rtc_set_output_high(false);
+                        Ok(())
+                    }
+                }
+
+                impl<MODE> embedded_hal::digital::v2::StatefulOutputPin for $pxi<RTCOutput<MODE>> {
+                    fn is_set_high(&self) -> Result<bool, Self::Error> {
+                        // NOTE(unsafe) atomic read to a stateless register
+                        Ok(unsafe{&*RTCIO::ptr()}.out.read().out_data().bits() & (1 << $pin_num) != 0)
+                    }
+
+                    fn is_set_low(&self) -> Result<bool, Self::Error> {
+                        Ok(!self.is_set_high()?)
+                    }
+                }
+
+                impl<MODE> embedded_hal::digital::v2::ToggleableOutputPin for $pxi<RTCOutput<MODE>> {
+                    type Error = Infallible;
+
+                    fn toggle(&mut self) -> Result<(), Self::Error> {
+                        if self.is_set_high()? {
+                            Ok(self.set_low()?)
+                        } else {
+                            Ok(self.set_high()?)
+                        }
+                    }
+                }
+
+                impl<MODE> RTCOutputPin for $pxi<MODE> {
+                    /// Enable/disable the output
+                    fn rtc_enable_output(&mut self, on: bool) -> &mut Self {
+                        unsafe {
+                            if on {
+                                (&*RTCIO::ptr()).enable_w1ts.modify(|_,w|
+                                    w.enable_w1ts().bits(1 << $pin_num));
+                            } else {
+                                (&*RTCIO::ptr()).enable_w1tc.modify(|_,w|
+                                    w.enable_w1tc().bits(1 << $pin_num));
+                            }
+                        }
+                        self
+                    }
+
+                    /// Set the output to high or low
+                    fn rtc_set_output_high(&mut self, on: bool) -> &mut Self {
+                        unsafe {
+                            if on {
+                                (&*RTCIO::ptr()).out_w1ts.modify(|_,w|
+                                    w.out_data_w1ts().bits(1 << $pin_num));
+                            } else {
+                                (&*RTCIO::ptr()).out_w1tc.modify(|_,w|
+                                    w.out_data_w1tc().bits(1 << $pin_num));
+                            }
+                        }
+                        self
+                    }
+
+                    /// Set drive strength
+                    fn rtc_set_drive_strength(&mut self, strength: DriveStrength) -> &mut Self {
+                        // shared register without set/clear functionality, so needs lock
+                        (&RTCIO_LOCK).lock(|_|
+                            unsafe{ &*RTCIO::ptr() }.$pin_reg.modify(|_,w|
+                                unsafe {w.$drv().bits(strength as u8)}
+                            )
+                        );
+                        self
+                    }
+
+                    /// Enable/Disable open drain
+                    fn rtc_enable_open_drain(&mut self, on: bool) -> &mut Self {
+                        unsafe{ &*RTCIO::ptr() }.pin[$pin_num].modify(|_,w|
+                            w.pad_driver().bit(on));
+                        self
+                    }
+
+                    /// Enable/disable the output while in sleep mode
+                    fn rtc_enable_output_in_sleep_mode(&mut self, on: bool) -> &mut Self {
+                        // shared register without set/clear functionality, so needs lock
+                        (&RTCIO_LOCK).lock(|_|
+                            unsafe{ &*RTCIO::ptr() }.$pin_reg.modify(|_,w| w.$slp_oe().bit(on))
+                        );
+                        self
+                    }
+                }
+            )?
+
             impl<MODE> $pxi<MODE> {
-                pub fn into_analog(self) -> $pxi<Analog> {
-                    let rtcio = unsafe{ &*RTCIO::ptr() };
 
-                    rtcio.$pin_reg.modify(|_,w| {
-                        // Connect pin to analog / RTC module instead of standard GPIO
-                        w.$mux_sel().set_bit();
+                fn init_rtc(&mut self, input: bool, _output: bool, _open_drain: bool, _pull_up: bool, _pull_down:bool) {
+                    // shared registers without set/clear functionality, so needs lock
+                    self.rtc_enable_input(input);
 
-                        // Select function "RTC function 1" (GPIO) for analog use
-                        unsafe { w.$fun_select().bits(0b00) }
-                    });
-
-                    // Configure RTC pin as normal output (instead of open drain)
-                    rtcio.pin[$pin_num].modify(|_,w| w.pad_driver().clear_bit());
-
-                    // Disable output
-                    rtcio.enable_w1tc.modify(|_,w| {
-                        unsafe { w.enable_w1tc().bits(1u32 << $pin_num) }
-                    });
-
-                    // Disable input
-                    rtcio.$pin_reg.modify(|_,w| w.$in_enable().clear_bit());
-
-                    // Disable pull-up and pull-down resistors on the pin, if it has them
                     $(
-                        rtcio.$pin_reg.modify(|_,w| {
-                            w.$rue().clear_bit().$rde().clear_bit()
+                        self.rtc_enable_output(_output);
+                        self.rtc_enable_open_drain(_open_drain);
+
+                        (&RTCIO_LOCK).lock(|_| {
+                            let rtcio = unsafe{ &*RTCIO::ptr() };
+
+                            rtcio.$pin_reg.modify(|_,w| {
+                                // Connect pin to analog / RTC module instead of standard GPIO
+                                w.$mux_sel().set_bit();
+
+                                // Select function "RTC function 1" (GPIO) for analog use
+                                unsafe { w.$fun_sel().bits(0b00) }
+                            });
+
+                                // Disable pull-up and pull-down resistors on the pin, if it has them
+                            rtcio.$pin_reg.modify(|_,w| {
+                                w
+                                .$rue().bit(_pull_up)
+                                .$rde().bit(_pull_down)
+                            });
                         });
                     )?
+                }
 
+                pub fn into_analog(mut self) -> $pxi<Analog> {
+                    self.init_rtc(false, false, false, false, false);
                     $pxi { _mode: PhantomData }
                 }
 
+                pub fn into_floating_rtc_input(mut self) -> $pxi<RTCInput<Floating>> {
+                    self.init_rtc(true, false, false, false, false);
+                    $pxi { _mode: PhantomData }
+                }
+
+                pub fn into_pull_up_rtc_input(mut self) -> $pxi<RTCInput<PullUp>> {
+                    self.init_rtc(true, false, false, false, false);
+                    $pxi { _mode: PhantomData }
+                }
+
+                pub fn into_pull_down_rtc_input(mut self) -> $pxi<RTCInput<PullDown>> {
+                    self.init_rtc(true, false, false, false, false);
+                    $pxi { _mode: PhantomData }
+                }
+
+                $(
+                    pub fn into_push_pull_rtc_output(mut self) -> $pxi<RTCOutput<PushPull>> {
+                        #[allow(unused_variables)]
+                        let $rde:();
+
+                        self.init_rtc(false, true, false, false, false);
+                        $pxi { _mode: PhantomData }
+                    }
+
+                    pub fn into_open_drain_rtc_output(mut self) -> $pxi<RTCOutput<OpenDrain>> {
+                        self.init_rtc(false, true, true, false, false);
+                        $pxi { _mode: PhantomData }
+                    }
+                )?
+
                 #[inline(always)]
                 fn disable_analog(&self) {
-                    let rtcio = unsafe{ &*RTCIO::ptr() };
+                    // shared register without set/clear functionality, so needs lock
+                    (&RTCIO_LOCK).lock(|_| {
+                        let rtcio = unsafe{ &*RTCIO::ptr() };
 
-                    rtcio.$pin_reg.modify(|_,w| w.$mux_sel().clear_bit());
+                        rtcio.$pin_reg.modify(|_,w| w.$mux_sel().clear_bit());
 
-                    $(
-                        rtcio.$pin_reg.modify(|_,w| {
-                            w.$rue().clear_bit().$rde().clear_bit()
-                        });
-                    )?
+                        // Disable pull-up and -down resistors by default
+                        $(
+                            rtcio.$pin_reg.modify(|_,w|
+                                w.$rue().clear_bit().$rde().clear_bit()
+                            );
+                        )?
+                    });
+                }
 
+                fn rtc_enable_wake_up_from_light_sleep(&self, event: Event, enable: bool) {
+                    unsafe{ &*RTCIO::ptr() }.pin[$pin_num].modify(|_,w| unsafe{
+                        w
+                            .wakeup_enable().bit(enable)
+                            .int_type().bits(if enable {event as u8} else {0})
+                    });
+                }
+
+                fn enable_hold_internal(&self, on: bool) {
+                    // shared register without set/clear functionality, so needs lock
+                    (&RTCIO_LOCK).lock(|_|
+                        unsafe{ &*RTCIO::ptr() }.$pin_reg.modify(|_, w| { w.$hold().bit(on) })
+                    );
                 }
             }
 
@@ -1004,16 +1280,18 @@ macro_rules! impl_analog {
                 // via RTC_MUX
                 impl<MODE> Pull for $pxi<MODE> {
                     fn internal_pull_up(&mut self, on: bool) -> &mut Self {
-                        unsafe{ &*RTCIO::ptr() }.$pin_reg.modify(|_,w| {
-                            w.$rue().bit(on)
-                        });
+                    // shared register without set/clear functionality, so needs lock
+                    (&RTCIO_LOCK).lock(|_|
+                            unsafe{ &*RTCIO::ptr() }.$pin_reg.modify(|_,w| { w.$rue().bit(on) })
+                        );
                         self
                     }
 
                     fn internal_pull_down(&mut self, on: bool) -> &mut Self {
-                        unsafe{ &*RTCIO::ptr() }.$pin_reg.modify(|_,w| {
-                            w.$rde().bit(on)
-                        });
+                        // shared register without set/clear functionality, so needs lock
+                        (&RTCIO_LOCK).lock(|_|
+                            unsafe{ &*RTCIO::ptr() }.$pin_reg.modify(|_,w| { w.$rde().bit(on) })
+                        );
                         self
                     }
                 }
@@ -1024,22 +1302,22 @@ macro_rules! impl_analog {
 }
 
 impl_analog! {[
-    Gpio36: (0, sensor_pads, sense1_mux_sel, sense1_fun_sel, sense1_fun_ie,),
-    Gpio37: (1, sensor_pads, sense2_mux_sel, sense2_fun_sel, sense2_fun_ie,),
-    Gpio38: (2, sensor_pads, sense3_mux_sel, sense3_fun_sel, sense3_fun_ie,),
-    Gpio39: (3, sensor_pads, sense4_mux_sel, sense4_fun_sel, sense4_fun_ie,),
-    Gpio34: (4, adc_pad, adc1_mux_sel, adc1_fun_sel, adc1_fun_ie,),
-    Gpio35: (5, adc_pad, adc2_mux_sel, adc2_fun_sel, adc1_fun_ie,),
-    Gpio25: (6, pad_dac1, pdac1_mux_sel, pdac1_fun_sel, pdac1_fun_ie, pdac1_rue, pdac1_rde),
-    Gpio26: (7, pad_dac2, pdac2_mux_sel, pdac2_fun_sel, pdac2_fun_ie, pdac2_rue, pdac2_rde),
-    Gpio33: (8, xtal_32k_pad, x32n_mux_sel, x32n_fun_sel, x32n_fun_ie, x32n_rue, x32n_rde),
-    Gpio32: (9, xtal_32k_pad, x32p_mux_sel, x32p_fun_sel, x32p_fun_ie, x32p_rue, x32p_rde),
-    Gpio4:  (10, touch_pad0, mux_sel, fun_sel, fun_ie, rue, rde),
-    Gpio0:  (11, touch_pad1, mux_sel, fun_sel, fun_ie, rue, rde),
-    Gpio2:  (12, touch_pad2, mux_sel, fun_sel, fun_ie, rue, rde),
-    Gpio15: (13, touch_pad3, mux_sel, fun_sel, fun_ie, rue, rde),
-    Gpio13: (14, touch_pad4, mux_sel, fun_sel, fun_ie, rue, rde),
-    Gpio12: (15, touch_pad5, mux_sel, fun_sel, fun_ie, rue, rde),
-    Gpio14: (16, touch_pad6, mux_sel, fun_sel, fun_ie, rue, rde),
-    Gpio27: (17, touch_pad7, mux_sel, fun_sel, fun_ie, rue, rde),
+    Gpio36: (0,  sensor_pads,  sense1_hold, sense1_mux_sel, sense1_fun_sel, sense1_fun_ie, sense1_slp_ie, sense1_slp_sel ),
+    Gpio37: (1,  sensor_pads,  sense2_hold, sense2_mux_sel, sense2_fun_sel, sense2_fun_ie, sense2_slp_ie, sense2_slp_sel ),
+    Gpio38: (2,  sensor_pads,  sense3_hold, sense3_mux_sel, sense3_fun_sel, sense3_fun_ie, sense3_slp_ie, sense3_slp_sel ),
+    Gpio39: (3,  sensor_pads,  sense4_hold, sense4_mux_sel, sense4_fun_sel, sense4_fun_ie, sense4_slp_ie, sense4_slp_sel ),
+    Gpio34: (4,  adc_pad,      adc1_hold,   adc1_mux_sel,   adc1_fun_sel,   adc1_fun_ie,   adc1_slp_ie,   adc1_slp_sel   ),
+    Gpio35: (5,  adc_pad,      adc2_hold,   adc2_mux_sel,   adc2_fun_sel,   adc1_fun_ie,   adc1_slp_ie,   adc1_slp_sel   ),
+    Gpio25: (6,  pad_dac1,     pdac1_hold,  pdac1_mux_sel,  pdac1_fun_sel,  pdac1_fun_ie,  pdac1_slp_ie,  pdac1_slp_sel,  pdac1_rue, pdac1_rde, pdac1_drv, pdac1_slp_oe),
+    Gpio26: (7,  pad_dac2,     pdac2_hold,  pdac2_mux_sel,  pdac2_fun_sel,  pdac2_fun_ie,  pdac2_slp_ie,  pdac2_slp_sel,  pdac2_rue, pdac2_rde, pdac2_drv, pdac2_slp_oe),
+    Gpio33: (8,  xtal_32k_pad, x32n_hold,   x32n_mux_sel,   x32n_fun_sel,   x32n_fun_ie,   x32n_slp_ie,   x32n_slp_sel,   x32n_rue,  x32n_rde,  x32n_drv,  x32n_slp_oe),
+    Gpio32: (9,  xtal_32k_pad, x32p_hold,   x32p_mux_sel,   x32p_fun_sel,   x32p_fun_ie,   x32p_slp_ie,   x32p_slp_sel,   x32p_rue,  x32p_rde,  x32p_drv,  x32p_slp_oe),
+    Gpio4:  (10, touch_pad0,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
+    Gpio0:  (11, touch_pad1,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
+    Gpio2:  (12, touch_pad2,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
+    Gpio15: (13, touch_pad3,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
+    Gpio13: (14, touch_pad4,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
+    Gpio12: (15, touch_pad5,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
+    Gpio14: (16, touch_pad6,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
+    Gpio27: (17, touch_pad7,   hold,        mux_sel,        fun_sel,        fun_ie,        slp_ie,        slp_sel,        rue,       rde,       drv,       slp_oe),
 ]}

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -1,5 +1,14 @@
 //! GPIO and pin configuration
 //!
+//! ESP32 has very flexible pin assignment via the GPIO mux. It also has a separate RTC mux for
+//! low power and analog functions.
+//!
+//! To support this flexibility two sets of traits are supported:
+//! - The various embedded_hal properties
+//! - Dedicated [InputPin], [OutputPin], [RTCInputPin] and [RTCOutputPin]
+//!
+//! The advantage of using the dedicated traits in peripherals is that the configuration of the
+//! IO can be done inside the peripheral instead of having to be done upfront.
 
 use {
     crate::target::{GPIO, IO_MUX, RTCIO},

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -708,7 +708,7 @@ macro_rules! impl_input {
 
             fn clear_interrupt(&mut self) {
                 unsafe {&*GPIO::ptr()}.$status_w1tc.write(|w|
-                    unsafe {w.status_int_w1tc().bits(1 << $bit)})
+                    unsafe {w.bits(1 << $bit)})
             }
 
             fn is_interrupt_set(&mut self) -> bool {
@@ -744,7 +744,7 @@ macro_rules! impl_input_wrap {
         $( ,( $( $af_input_signal:ident: $af_input:ident ),* ))?
     ) => {
         impl_input!($pxi: ($pin_num, $pin_num % 32, $iomux, enable1_w1tc, in1, in1_data,
-            status_w1tc, acpu_int, acpu_nmi_int, pcpu_int, pcpu_nmi_int)
+            status1_w1tc, acpu_int1, acpu_nmi_int1, pcpu_int1, pcpu_nmi_int1)
             $( ,( $( $af_input_signal: $af_input ),* ) )? );
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub use proc_macros::ram;
 
 pub mod analog;
 pub mod clock_control;
+pub mod delay;
 pub mod dport;
 pub mod efuse;
 #[cfg(feature = "external_ram")]
@@ -37,6 +38,7 @@ pub mod gpio;
 pub mod interrupt;
 pub mod prelude;
 pub mod serial;
+pub mod spi;
 pub mod timer;
 pub mod units;
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,0 +1,854 @@
+//! SPI peripheral control
+//!
+//! Currently only implements full duplex controller mode support.
+//!
+//! SPI0 is reserved for accessing flash and sram and therefore not usable for other purposes.
+//! SPI1 shares its external pins with SPI0 and therefore has severe restrictions in use.
+//!
+//! SPI2 &3 can be used freely.
+//!
+//! The CS pin is controlled by hardware on esp32 (contrary to the description of embedded_hal).
+//!
+//! The [Transfer::transfer], [Write::write] and [WriteIter::write_iter] functions lock the
+//! APB frequency and therefore the requests are always run at the requested baudrate.
+//! The primitive [FullDuplex::read] and [FullDuplex::send] do not lock the APB frequency and
+//! therefore may run at a different frequency.
+
+use {
+    crate::{
+        clock_control::ClockControlConfig,
+        gpio::{self, InputPin, OutputPin},
+        target::{self, SPI1, SPI2, SPI3},
+        units::*,
+    },
+    core::convert::TryInto,
+    embedded_hal::blocking::spi::{Transfer, Write, WriteIter},
+    embedded_hal::spi::FullDuplex,
+};
+
+use private::Instance;
+
+/// SPI Errors
+#[derive(Debug)]
+pub enum Error {
+    BaudrateTooHigh,
+    BaudrateTooLow,
+    ConversionFailed,
+    PinError,
+}
+
+/// Pins used by the SPI interface
+pub struct Pins<
+    SCLK: OutputPin,
+    SDO: OutputPin,
+    // default pins to allow type inference
+    SDI: InputPin + OutputPin = crate::gpio::Gpio1<crate::gpio::Input<crate::gpio::Floating>>,
+    CS: OutputPin = crate::gpio::Gpio2<crate::gpio::Output<crate::gpio::PushPull>>,
+> {
+    pub sclk: SCLK,
+    pub sdo: SDO,
+    pub sdi: Option<SDI>,
+    pub cs: Option<CS>,
+}
+
+/// SPI configuration
+pub mod config {
+    use crate::units::*;
+    pub use embedded_hal::spi::{Mode, MODE_0, MODE_1, MODE_2, MODE_3};
+
+    /// SPI Bit Order
+    #[derive(PartialEq, Eq, Copy, Clone)]
+    pub enum BitOrder {
+        LSBFirst,
+        MSBFirst,
+    }
+
+    /// SPI configuration
+    #[derive(Copy, Clone)]
+    pub struct Config {
+        pub baudrate: Hertz,
+        pub data_mode: embedded_hal::spi::Mode,
+        pub bit_order: BitOrder,
+    }
+
+    impl Config {
+        pub fn baudrate(mut self, baudrate: Hertz) -> Self {
+            self.baudrate = baudrate;
+            self
+        }
+
+        pub fn data_mode(mut self, data_mode: embedded_hal::spi::Mode) -> Self {
+            self.data_mode = data_mode;
+            self
+        }
+
+        pub fn bit_order(mut self, bit_order: BitOrder) -> Self {
+            self.bit_order = bit_order;
+            self
+        }
+    }
+
+    impl Default for Config {
+        fn default() -> Config {
+            Config {
+                baudrate: Hertz(1_000_000),
+                data_mode: MODE_0,
+                bit_order: BitOrder::LSBFirst,
+            }
+        }
+    }
+}
+
+/// SPI abstraction
+pub struct SPI<
+    INSTANCE: Instance,
+    SCLK: OutputPin,
+    SDO: OutputPin,
+    // default pins to allow type inference
+    SDI: InputPin + OutputPin = crate::gpio::Gpio1<crate::gpio::Input<crate::gpio::Floating>>,
+    CS: OutputPin = crate::gpio::Gpio2<crate::gpio::Output<crate::gpio::PushPull>>,
+> {
+    instance: INSTANCE,
+    pins: Pins<SCLK, SDO, SDI, CS>,
+    clock_control: ClockControlConfig,
+}
+
+impl<CS: OutputPin>
+    SPI<
+        SPI1,
+        gpio::Gpio6<gpio::Output<gpio::PushPull>>,
+        gpio::Gpio7<gpio::Output<gpio::PushPull>>,
+        gpio::Gpio8<gpio::Input<gpio::Floating>>,
+        CS,
+    >
+{
+    /// Create new instance of SPI controller for SPI1
+    ///
+    /// SPI1 can only use fixed pin for SCLK, SDO and SDI as they are shared with SPI0.
+    pub fn new(
+        instance: SPI1,
+        pins: Pins<
+            gpio::Gpio6<gpio::Output<gpio::PushPull>>,
+            gpio::Gpio7<gpio::Output<gpio::PushPull>>,
+            gpio::Gpio8<gpio::Input<gpio::Floating>>,
+            CS,
+        >,
+        config: config::Config,
+        clock_control: ClockControlConfig,
+        dport: &mut target::DPORT,
+    ) -> Result<Self, Error> {
+        SPI::new_internal(instance, pins, config, clock_control, dport)
+    }
+}
+
+impl<SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: OutputPin>
+    SPI<SPI2, SCLK, SDO, SDI, CS>
+{
+    /// Create new instance of SPI controller for SPI2
+    pub fn new(
+        instance: SPI2,
+        pins: Pins<SCLK, SDO, SDI, CS>,
+        config: config::Config,
+        clock_control: ClockControlConfig,
+        dport: &mut target::DPORT,
+    ) -> Result<Self, Error> {
+        SPI::new_internal(instance, pins, config, clock_control, dport)
+    }
+}
+
+impl<SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: OutputPin>
+    SPI<SPI3, SCLK, SDO, SDI, CS>
+{
+    /// Create new instance of SPI controller for SPI3
+    pub fn new(
+        instance: SPI3,
+        pins: Pins<SCLK, SDO, SDI, CS>,
+        config: config::Config,
+        clock_control: ClockControlConfig,
+        dport: &mut target::DPORT,
+    ) -> Result<Self, Error> {
+        SPI::new_internal(instance, pins, config, clock_control, dport)
+    }
+}
+
+impl<
+        INSTANCE: Instance,
+        SCLK: OutputPin,
+        SDO: OutputPin,
+        SDI: InputPin + OutputPin,
+        CS: OutputPin,
+    > SPI<INSTANCE, SCLK, SDO, SDI, CS>
+{
+    /// Internal implementation of new shared by all SPI controllers
+    fn new_internal(
+        instance: INSTANCE,
+        pins: Pins<SCLK, SDO, SDI, CS>,
+        config: config::Config,
+        clock_control: ClockControlConfig,
+        dport: &mut target::DPORT,
+    ) -> Result<Self, Error> {
+        let mut spi = SPI {
+            instance,
+            pins,
+            clock_control,
+        };
+
+        spi.instance.init_pins(&mut spi.pins);
+        spi.instance.enable(dport).reset(dport);
+
+        // initialize registers to defaults (this is for a large part also done by the peripheral
+        // reset), however SPI0 and 1 cannot be reset independently.
+        spi.instance
+            .slave
+            .modify(|_, w| w.trans_done().clear_bit().slave_mode().clear_bit());
+
+        unsafe {
+            spi.instance.user.write(|w| {
+                w.bits(0)
+                    .usr_mosi()
+                    .set_bit()
+                    .usr_miso()
+                    .set_bit()
+                    .doutdin()
+                    .set_bit()
+                    .cs_setup()
+                    .set_bit()
+                    .cs_hold()
+                    .set_bit()
+            });
+            spi.instance.user1.write(|w| w.bits(0));
+            spi.instance.ctrl.write(|w| w.bits(0));
+            spi.instance.ctrl1.write(|w| w.bits(0));
+            spi.instance.ctrl2.write(|w| w.bits(0));
+            spi.instance.clock.write(|w| w.bits(0));
+        }
+
+        spi.change_data_mode(config.data_mode)
+            .change_bit_order(config.bit_order)
+            .change_baudrate(config.baudrate)?;
+
+        Ok(spi)
+    }
+
+    /// Convert SPI division factor back to frequency
+    fn divider_to_frequency(apb_freq: Hertz, div1: u32, div2: u32) -> Hertz {
+        apb_freq / ((div1 + 1) * (div2 + 1))
+    }
+
+    /// Change the SPI baudrate
+    pub fn change_baudrate<T: Into<Hertz> + Copy>(
+        &mut self,
+        baudrate: T,
+    ) -> Result<&mut Self, Error> {
+        let baudrate = baudrate.into();
+        let apb_freq = self.clock_control.apb_frequency_apb_locked();
+
+        if baudrate > apb_freq {
+            return Err(Error::BaudrateTooHigh);
+        }
+
+        if baudrate == apb_freq {
+            self.instance.clock.write(|w| unsafe {
+                w.clk_equ_sysclk()
+                    .set_bit()
+                    .clkdiv_pre()
+                    .bits(0)
+                    .clkcnt_n()
+                    .bits(0)
+                    .clkcnt_h()
+                    .bits(0)
+                    .clkcnt_l()
+                    .bits(0)
+            });
+            return Ok(self);
+        }
+
+        if baudrate < Self::divider_to_frequency(apb_freq, 0x1fff, 0x3f) {
+            return Err(Error::BaudrateTooLow);
+        }
+
+        let mut div1: u16 = 1;
+        let mut div2: u8 = 1;
+        let mut freq_best: Hertz = Hertz(0);
+
+        'outer: for div2_guess in 1..=0x3f {
+            for var in -2i32..=1 {
+                let mut div1_guess = (((apb_freq / (div2_guess + 1)) / baudrate) as i32 - 1) + var;
+                if div1_guess > 0x1fff {
+                    div1_guess = 0x1fff;
+                } else if div1_guess <= 0 {
+                    div1_guess = 0;
+                }
+                let freq_guess =
+                    Self::divider_to_frequency(apb_freq, div1_guess as u32, div2_guess);
+
+                if freq_guess <= baudrate
+                    && (u32::from(baudrate) as i32 - u32::from(freq_guess) as i32).abs()
+                        < (u32::from(baudrate) as i32 - u32::from(freq_best) as i32).abs()
+                {
+                    freq_best = freq_guess;
+                    div1 = div1_guess as u16;
+                    div2 = div2_guess as u8;
+
+                    if baudrate == freq_guess {
+                        break 'outer;
+                    }
+                }
+            }
+        }
+
+        self.instance.clock.write(|w| unsafe {
+            w.clk_equ_sysclk()
+                .clear_bit()
+                .clkdiv_pre()
+                .bits(div1)
+                .clkcnt_n()
+                .bits(div2)
+                .clkcnt_l()
+                .bits((div2 + 1) / 2)
+                .clkcnt_h()
+                .bits(0)
+        });
+
+        Ok(self)
+    }
+
+    /// Returns the current baudrate
+    pub fn baudrate(&self) -> Hertz {
+        if self.instance.clock.read().clk_equ_sysclk().bit_is_set() {
+            self.clock_control.apb_frequency_apb_locked()
+        } else {
+            Self::divider_to_frequency(
+                self.clock_control.apb_frequency_apb_locked(),
+                self.instance.clock.read().clkdiv_pre().bits() as u32,
+                self.instance.clock.read().clkcnt_n().bits() as u32,
+            )
+        }
+    }
+
+    /// Change the bit order
+    pub fn change_bit_order(&mut self, data_mode: config::BitOrder) -> &mut Self {
+        let spi = &self.instance;
+        match data_mode {
+            config::BitOrder::LSBFirst => spi
+                .ctrl
+                .modify(|_, w| w.wr_bit_order().set_bit().rd_bit_order().set_bit()),
+            config::BitOrder::MSBFirst => spi
+                .ctrl
+                .modify(|_, w| w.wr_bit_order().clear_bit().rd_bit_order().clear_bit()),
+        }
+        self
+    }
+
+    /// Change the data mode
+    pub fn change_data_mode(&mut self, data_mode: embedded_hal::spi::Mode) -> &mut Self {
+        let spi = &self.instance;
+        match data_mode {
+            embedded_hal::spi::MODE_0 => {
+                spi.pin.modify(|_, w| w.ck_idle_edge().clear_bit());
+                spi.user.modify(|_, w| w.ck_out_edge().clear_bit());
+            }
+            embedded_hal::spi::MODE_1 => {
+                spi.pin.modify(|_, w| w.ck_idle_edge().clear_bit());
+                spi.user.modify(|_, w| w.ck_out_edge().set_bit());
+            }
+            embedded_hal::spi::MODE_2 => {
+                spi.pin.modify(|_, w| w.ck_idle_edge().set_bit());
+                spi.user.modify(|_, w| w.ck_out_edge().set_bit());
+            }
+            embedded_hal::spi::MODE_3 => {
+                spi.pin.modify(|_, w| w.ck_idle_edge().set_bit());
+                spi.user.modify(|_, w| w.ck_out_edge().clear_bit());
+            }
+        }
+        self
+    }
+
+    /// Release and return the raw interface to the underlying SPI peripheral
+    pub fn release(self) -> INSTANCE {
+        self.instance
+    }
+
+    /// Generic transfer function
+    ///
+    /// This function locks the APB bus frequency and chunks the output
+    /// for maximum write performance.
+    fn transfer_internal<'a, T>(&mut self, words: &'a mut [T]) -> Result<&'a [T], Error>
+    where
+        T: U8orU16orU32,
+    {
+        let bytes = core::mem::size_of::<T>();
+        let bits = bytes * 8;
+        let divider = 4 / bytes;
+        let buffer_item_count = 64 / bytes;
+
+        let apb_lock = self.clock_control.lock_apb_frequency();
+
+        let mut item_count = 0;
+        let mut read_item_count = 0;
+
+        while read_item_count < words.len() {
+            // wait till SPI is finished with previous command
+            while self.instance.cmd.read().usr().bit_is_set() {}
+
+            // get data from previous SPI chunk
+            if item_count > 0 {
+                for count in 0..buffer_item_count {
+                    words[read_item_count] = ((self.instance.w[count / divider].read().bits()
+                        >> ((count % divider) * bits))
+                        & ((!0u32) >> (32 - bits)))
+                        .try_into()
+                        .map_err(|_| Error::ConversionFailed)?;
+
+                    read_item_count += 1;
+                    if read_item_count >= words.len() {
+                        break;
+                    }
+                }
+            }
+
+            if item_count < words.len() {
+                // write next SPI chunk to buffer
+                let mut count = 0;
+                let mut buffer = 0;
+                while count < buffer_item_count && item_count < words.len() {
+                    if count % divider == 0 {
+                        buffer = words[item_count].into();
+                    } else {
+                        buffer |= (words[item_count].into()) << ((count % divider) * bits);
+                    }
+                    if count % divider == divider - 1 || item_count == words.len() - 1 {
+                        self.instance.w[count / divider].write(|w| unsafe { w.bits(buffer) });
+                    }
+
+                    count += 1;
+                    item_count += 1;
+                }
+
+                self.instance
+                    .mosi_dlen
+                    .write(|w| unsafe { w.usr_mosi_dbitlen().bits((count * bits - 1) as u32) });
+                self.instance
+                    .miso_dlen
+                    .write(|w| unsafe { w.usr_miso_dbitlen().bits((count * bits - 1) as u32) });
+
+                self.instance.cmd.modify(|_, w| w.usr().set_bit());
+            }
+        }
+
+        drop(apb_lock);
+
+        Ok(words)
+    }
+
+    /// Generic write function for iterators
+    ///
+    /// This function locks the APB bus frequency and chunks the output of the iterator
+    /// for maximum write performance.
+    fn write_iter_internal<T, WI>(&mut self, words: WI) -> Result<(), Error>
+    where
+        T: U8orU16orU32,
+        WI: IntoIterator<Item = T>,
+    {
+        let bytes = core::mem::size_of::<T>();
+        let bits = bytes * 8;
+        let divider = 4 / bytes;
+        let buffer_item_count = 64 / bytes;
+
+        let apb_lock = self.clock_control.lock_apb_frequency();
+
+        let mut iter = words.into_iter().peekable();
+
+        let mut buffer: [u32; 16] = [0; 16];
+
+        while iter.peek().is_some() {
+            let chunk = iter.by_ref().take(buffer_item_count);
+
+            let mut count = 0;
+            for value in chunk {
+                if count % divider == 0 {
+                    buffer[count / divider] = value.into();
+                } else {
+                    buffer[count / divider] |= (value.into()) << ((count % divider) * bits);
+                }
+                count = count + 1;
+            }
+
+            while self.instance.cmd.read().usr().bit_is_set() {}
+
+            for i in 0..((count + divider - 1) / divider) {
+                self.instance.w[i].write(|w| unsafe { w.bits(buffer[i]) });
+            }
+
+            self.instance
+                .mosi_dlen
+                .write(|w| unsafe { w.usr_mosi_dbitlen().bits((count * bits - 1) as u32) });
+            self.instance
+                .miso_dlen
+                .write(|w| unsafe { w.usr_miso_dbitlen().bits((count * bits - 1) as u32) });
+
+            self.instance.cmd.modify(|_, w| w.usr().set_bit());
+        }
+
+        while self.instance.cmd.read().usr().bit_is_set() {}
+
+        drop(apb_lock);
+
+        Ok(())
+    }
+}
+
+pub trait U8orU16orU32: core::convert::TryFrom<u32> + Into<u32> + Sized + Copy + Clone {}
+
+impl U8orU16orU32 for u8 {}
+impl U8orU16orU32 for u16 {}
+impl U8orU16orU32 for u32 {}
+
+/// Full-duplex implementation for writing/reading via SPI
+///
+/// *Note: these functions do not lock the frequency of the APB bus, so transactions may be
+/// at lower frequency if APB bus is not locked in caller.*
+impl<
+        T: U8orU16orU32,
+        INSTANCE: Instance,
+        SCLK: OutputPin,
+        SDO: OutputPin,
+        SDI: InputPin + OutputPin,
+        CS: OutputPin,
+    > FullDuplex<T> for SPI<INSTANCE, SCLK, SDO, SDI, CS>
+{
+    type Error = Error;
+
+    fn read(&mut self) -> nb::Result<T, Error> {
+        let spi = &self.instance;
+
+        if spi.cmd.read().usr().bit_is_set() {
+            return Err(nb::Error::WouldBlock);
+        }
+
+        let bits = (core::mem::size_of::<T>() * 8) as u32;
+
+        (spi.w[0].read().bits() & (0xffffffff >> (32 - bits)))
+            .try_into()
+            .map_err(|_| nb::Error::Other(Error::ConversionFailed))
+    }
+
+    fn send(&mut self, value: T) -> nb::Result<(), Error> {
+        let spi = &self.instance;
+
+        if spi.cmd.read().usr().bit_is_set() {
+            return Err(nb::Error::WouldBlock);
+        }
+
+        let bits = (core::mem::size_of::<T>() * 8 - 1) as u32;
+
+        spi.mosi_dlen
+            .write(|w| unsafe { w.usr_mosi_dbitlen().bits(bits) });
+        spi.miso_dlen
+            .write(|w| unsafe { w.usr_miso_dbitlen().bits(bits) });
+        spi.w[0].write(|w| unsafe { w.bits(value.into()) });
+
+        spi.cmd.modify(|_, w| w.usr().set_bit());
+
+        Ok(())
+    }
+}
+
+// cannot use generics as it conflicts with the Default implementation
+impl<
+        INSTANCE: Instance,
+        SCLK: OutputPin,
+        SDO: OutputPin,
+        SDI: InputPin + OutputPin,
+        CS: OutputPin,
+    > Transfer<u8> for SPI<INSTANCE, SCLK, SDO, SDI, CS>
+{
+    type Error = Error;
+
+    fn transfer<'w>(&mut self, words: &'w mut [u8]) -> core::result::Result<&'w [u8], Self::Error> {
+        self.transfer_internal(words)
+    }
+}
+
+impl<
+        INSTANCE: Instance,
+        SCLK: OutputPin,
+        SDO: OutputPin,
+        SDI: InputPin + OutputPin,
+        CS: OutputPin,
+    > Transfer<u16> for SPI<INSTANCE, SCLK, SDO, SDI, CS>
+{
+    type Error = Error;
+
+    fn transfer<'w>(
+        &mut self,
+        words: &'w mut [u16],
+    ) -> core::result::Result<&'w [u16], Self::Error> {
+        self.transfer_internal(words)
+    }
+}
+
+impl<
+        INSTANCE: Instance,
+        SCLK: OutputPin,
+        SDO: OutputPin,
+        SDI: InputPin + OutputPin,
+        CS: OutputPin,
+    > Transfer<u32> for SPI<INSTANCE, SCLK, SDO, SDI, CS>
+{
+    type Error = Error;
+
+    fn transfer<'w>(
+        &mut self,
+        words: &'w mut [u32],
+    ) -> core::result::Result<&'w [u32], Self::Error> {
+        self.transfer_internal(words)
+    }
+}
+
+// cannot use generics as it conflicts with the Default implementation
+impl<
+        INSTANCE: Instance,
+        SCLK: OutputPin,
+        SDO: OutputPin,
+        SDI: InputPin + OutputPin,
+        CS: OutputPin,
+    > Write<u8> for SPI<INSTANCE, SCLK, SDO, SDI, CS>
+{
+    type Error = Error;
+
+    fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+        self.write_iter_internal(words.iter().copied())
+    }
+}
+
+impl<
+        INSTANCE: Instance,
+        SCLK: OutputPin,
+        SDO: OutputPin,
+        SDI: InputPin + OutputPin,
+        CS: OutputPin,
+    > Write<u16> for SPI<INSTANCE, SCLK, SDO, SDI, CS>
+{
+    type Error = Error;
+
+    fn write(&mut self, words: &[u16]) -> Result<(), Self::Error> {
+        self.write_iter_internal(words.iter().copied())
+    }
+}
+
+// this could be further optimized with a dedicated function to skip the buffer
+impl<
+        INSTANCE: Instance,
+        SCLK: OutputPin,
+        SDO: OutputPin,
+        SDI: InputPin + OutputPin,
+        CS: OutputPin,
+    > Write<u32> for SPI<INSTANCE, SCLK, SDO, SDI, CS>
+{
+    type Error = Error;
+
+    fn write(&mut self, words: &[u32]) -> Result<(), Self::Error> {
+        self.write_iter_internal(words.iter().copied())
+    }
+}
+
+// cannot use generics as it conflicts with the Default implementation
+impl<
+        INSTANCE: Instance,
+        SCLK: OutputPin,
+        SDO: OutputPin,
+        SDI: InputPin + OutputPin,
+        CS: OutputPin,
+    > WriteIter<u8> for SPI<INSTANCE, SCLK, SDO, SDI, CS>
+{
+    type Error = Error;
+
+    fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
+    where
+        WI: IntoIterator<Item = u8>,
+    {
+        self.write_iter_internal(words)
+    }
+}
+
+impl<
+        INSTANCE: Instance,
+        SCLK: OutputPin,
+        SDO: OutputPin,
+        SDI: InputPin + OutputPin,
+        CS: OutputPin,
+    > WriteIter<u16> for SPI<INSTANCE, SCLK, SDO, SDI, CS>
+{
+    type Error = Error;
+
+    fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
+    where
+        WI: IntoIterator<Item = u16>,
+    {
+        self.write_iter_internal(words)
+    }
+}
+
+impl<
+        INSTANCE: Instance,
+        SCLK: OutputPin,
+        SDO: OutputPin,
+        SDI: InputPin + OutputPin,
+        CS: OutputPin,
+    > WriteIter<u32> for SPI<INSTANCE, SCLK, SDO, SDI, CS>
+{
+    type Error = Error;
+
+    fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
+    where
+        WI: IntoIterator<Item = u32>,
+    {
+        self.write_iter_internal(words)
+    }
+}
+
+mod private {
+
+    use super::Pins;
+    use crate::gpio::{InputPin, InputSignal, OutputPin, OutputSignal};
+    use crate::target::{self, spi, SPI1, SPI2, SPI3};
+    use core::ops::Deref;
+
+    pub trait Instance: Deref<Target = spi::RegisterBlock> {
+        fn ptr() -> *const spi::RegisterBlock;
+        /// Enable peripheral
+        fn enable(&mut self, dport: &mut target::DPORT) -> &mut Self;
+        /// Disable peripheral
+        fn disable(&mut self, dport: &mut target::DPORT) -> &mut Self;
+        /// Reset peripheral
+        fn reset(&mut self, dport: &mut target::DPORT) -> &mut Self;
+
+        /// Initialize pins
+        fn init_pins<SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: OutputPin>(
+            &mut self,
+            pins: &mut Pins<SCLK, SDO, SDI, CS>,
+        ) -> &mut Self;
+    }
+
+    macro_rules! modules {
+        ($(
+            $MODULE:ident: ($module:ident, $sclk:ident, $sdo:ident, $sdi:ident, $cs:ident),
+        )+) => {
+            $(
+                impl Instance for $MODULE {
+                    fn ptr() -> *const spi::RegisterBlock {
+                        $MODULE::ptr()
+                    }
+
+                    fn reset(&mut self, dport: &mut target::DPORT) -> &mut Self {
+                        dport.perip_rst_en.modify(|_, w| w.$module().set_bit());
+                        dport.perip_rst_en.modify(|_, w| w.$module().clear_bit());
+                        self
+                    }
+
+                    fn enable(&mut self, dport: &mut target::DPORT) -> &mut Self {
+                        dport.perip_clk_en.modify(|_, w| w.$module().set_bit());
+                        dport.perip_rst_en.modify(|_, w| w.$module().clear_bit());
+                        self
+                    }
+
+                    fn disable(&mut self, dport: &mut target::DPORT) -> &mut Self {
+                        dport.perip_clk_en.modify(|_, w| w.$module().clear_bit());
+                        dport.perip_rst_en.modify(|_, w| w.$module().set_bit());
+                        self
+
+                    }
+
+                    fn init_pins<SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: OutputPin>(
+                        &mut self, pins: &mut Pins<SCLK,SDO,SDI,CS>
+                    ) -> &mut Self {
+                        pins
+                            .sclk
+                            .set_to_push_pull_output()
+                            .connect_peripheral_to_output(OutputSignal::$sclk);
+
+                        pins
+                            .sdo
+                            .set_to_push_pull_output()
+                            .connect_peripheral_to_output(OutputSignal::$sdo);
+
+                        if let Some(sdi)=&mut pins.sdi {
+                            sdi
+                                .set_to_input()
+                                .connect_input_to_peripheral(InputSignal::$sdi);
+                            sdi.internal_pull_up(true);
+                        }
+
+                        if let Some(cs) = & mut pins.cs {
+                            cs
+                                .set_to_push_pull_output()
+                                .connect_peripheral_to_output(OutputSignal::$cs);
+                        }
+
+                        // Use CS0
+                        self
+                            .pin
+                            .write(|w| unsafe {w.bits(0).cs1_dis().set_bit().cs2_dis().set_bit()});
+
+
+                        self
+                    }
+                }
+            )+
+        }
+    }
+
+    modules! {
+    // SPI0 is reserved for accessing flash/sram
+        SPI2: (spi2, HSPICLK, HSPID, HSPIQ, HSPICS0),
+        SPI3: (spi3, VSPICLK, VSPID, VSPIQ, VSPICS0),
+    }
+
+    impl Instance for SPI1 {
+        fn ptr() -> *const spi::RegisterBlock {
+            SPI1::ptr()
+        }
+
+        fn reset(&mut self, _dport: &mut target::DPORT) -> &mut Self {
+            // SPI0 and 1 share reset, should not reset SPI0 as it is used for flash
+
+            for i in 0..=15 {
+                unsafe { self.w[i].write(|w| w.bits(0)) };
+            }
+
+            self
+        }
+
+        fn enable(&mut self, dport: &mut target::DPORT) -> &mut Self {
+            dport.perip_clk_en.modify(|_, w| w.spi0().set_bit());
+            dport.perip_rst_en.modify(|_, w| w.spi0().clear_bit());
+            self
+        }
+
+        fn disable(&mut self, _dport: &mut target::DPORT) -> &mut Self {
+            // SPI0 and 1 share reset, should not disable SPI0 as it is used for flash
+            self
+        }
+
+        fn init_pins<SCLK: OutputPin, SDO: OutputPin, SDI: InputPin + OutputPin, CS: OutputPin>(
+            &mut self,
+            pins: &mut Pins<SCLK, SDO, SDI, CS>,
+        ) -> &mut Self {
+            // SCLK, SDO & SDI, pins are initialized and in use by SPI0, cannot change
+
+            // use CS2 signal, as CS is shared between SPI0 and SPI1 and CS0 is for flash,
+            // CS1 is for psram?
+
+            if let Some(cs) = &mut pins.cs {
+                cs.set_to_push_pull_output()
+                    .connect_peripheral_to_output(OutputSignal::SPICS2);
+            }
+
+            self.pin
+                .write(|w| unsafe { w.bits(0).cs0_dis().set_bit().cs1_dis().set_bit() });
+
+            self
+        }
+    }
+}

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -13,6 +13,12 @@
 //! APB frequency and therefore the requests are always run at the requested baudrate.
 //! The primitive [FullDuplex::read] and [FullDuplex::send] do not lock the APB frequency and
 //! therefore may run at a different frequency.
+//!
+//! # TODO
+//! - Quad SPI
+//! - Half Duplex
+//! - DMA
+//! - Multiple CS pins
 
 use {
     crate::{


### PR DESCRIPTION
SPI peripheral driver implements all basic SPI functionality at good speeds. 
It implements optimized versions of the embedded_hal::blocking::spi traits using the ESP32 16 x int32 hardware buffer for chunked transfers and iterator evaluation is done overlapped with the transmissions to achieve ~ 2.5us overhead between chunks.

It includes an examples using ESP32 WROVER DEVKIT LCD screen (using Ili9341 chip).

It does not yet include DMA, half-duplex or Quad SPI support. (I don't plan to implement this in the near future either, so I would recommend to merge this PR as-is.)

It needs a change in esp32: https://github.com/esp-rs/esp32/pull/37

Builds on PR #42 (although it is independent).