### PR TITLE
Various cleanups & extension of timer features in preparation of WiFi

### DIFF
--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -20,7 +20,7 @@ fn main() -> ! {
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;
 
-    let (mut dport, dport_clock_control) = dp.DPORT.split();
+    let (_, dport_clock_control) = dp.DPORT.split();
 
     // (https://github.com/espressif/openocd-esp32/blob/97ba3a6bb9eaa898d91df923bbedddfeaaaf28c9/src/target/esp32.c#L431)
     // openocd disables the watchdog timer on halt
@@ -50,7 +50,6 @@ fn main() -> ! {
         },
         Config::default(),
         clkcntrl_config,
-        &mut dport,
     )
     .unwrap();
 

--- a/examples/exception.rs
+++ b/examples/exception.rs
@@ -100,7 +100,7 @@ fn main() -> ! {
     // we will do it manually on startup
     disable_timg_wdts(&mut timg0, &mut timg1);
 
-    let (mut dport, dport_clock_control) = dp.DPORT.split();
+    let (_, dport_clock_control) = dp.DPORT.split();
 
     // setup clocks & watchdog
     let mut clock_control = ClockControl::new(
@@ -132,7 +132,6 @@ fn main() -> ! {
         },
         Config::default(),
         clock_control_config,
-        &mut dport,
     )
     .unwrap();
 

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -34,7 +34,7 @@ static GPIO: CriticalSectionSpinLockMutex<
 fn main() -> ! {
     let dp = target::Peripherals::take().unwrap();
 
-    let (mut dport, dport_clock_control) = dp.DPORT.split();
+    let (_, dport_clock_control) = dp.DPORT.split();
 
     let clkcntrl = esp32_hal::clock_control::ClockControl::new(
         dp.RTCCNTL,
@@ -73,7 +73,6 @@ fn main() -> ! {
         },
         Config::default().baudrate(115_200.Hz()),
         clkcntrl_config,
-        &mut dport,
     )
     .unwrap();
 

--- a/examples/hall.rs
+++ b/examples/hall.rs
@@ -20,7 +20,7 @@ fn main() -> ! {
     let mut timg0 = dp.TIMG0;
     let mut timg1 = dp.TIMG1;
 
-    let (mut dport, dport_clock_control) = dp.DPORT.split();
+    let (_, dport_clock_control) = dp.DPORT.split();
 
     // (https://github.com/espressif/openocd-esp32/blob/97ba3a6bb9eaa898d91df923bbedddfeaaaf28c9/src/target/esp32.c#L431)
     // openocd disables the watchdog timer on halt
@@ -50,7 +50,6 @@ fn main() -> ! {
         },
         Config::default(),
         clkcntrl_config,
-        &mut dport,
     )
     .unwrap();
 

--- a/examples/multicore.rs
+++ b/examples/multicore.rs
@@ -32,7 +32,7 @@ fn main() -> ! {
     // we will do it manually on startup
     disable_timg_wdts(&mut timg0, &mut timg1);
 
-    let (mut dport, dport_clock_control) = dp.DPORT.split();
+    let (_, dport_clock_control) = dp.DPORT.split();
 
     // setup clocks & watchdog
     let mut clock_control = ClockControl::new(
@@ -71,7 +71,6 @@ fn main() -> ! {
         },
         Config::default(),
         clock_control_config,
-        &mut dport,
     )
     .unwrap();
 

--- a/examples/ram.rs
+++ b/examples/ram.rs
@@ -26,7 +26,7 @@ fn main() -> ! {
     // we will do it manually on startup
     disable_timg_wdts(&mut timg0, &mut timg1);
 
-    let (mut dport, dport_clock_control) = dp.DPORT.split();
+    let (_, dport_clock_control) = dp.DPORT.split();
 
     // setup clocks & watchdog
     let clock_control = ClockControl::new(
@@ -53,7 +53,6 @@ fn main() -> ! {
         },
         Config::default(),
         clock_control_config,
-        &mut dport,
     )
     .unwrap();
 

--- a/examples/rtccntl.rs
+++ b/examples/rtccntl.rs
@@ -26,7 +26,7 @@ fn main() -> ! {
     // we will do it manually on startup
     disable_timg_wdts(&mut timg0, &mut timg1);
 
-    let (mut dport, dport_clock_control) = dp.DPORT.split();
+    let (_, dport_clock_control) = dp.DPORT.split();
 
     // setup clocks & watchdog
     let mut clock_control = ClockControl::new(
@@ -65,7 +65,6 @@ fn main() -> ! {
         },
         Config::default(),
         clock_control_config,
-        &mut dport,
     )
     .unwrap();
     uart0.change_baudrate(115200).unwrap();

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -19,7 +19,7 @@ const BLINK_HZ: Hertz = Hertz(2);
 fn main() -> ! {
     let dp = target::Peripherals::take().expect("Failed to obtain Peripherals");
 
-    let (mut dport, dport_clock_control) = dp.DPORT.split();
+    let (_, dport_clock_control) = dp.DPORT.split();
 
     let clkcntrl = ClockControl::new(
         dp.RTCCNTL,
@@ -56,7 +56,6 @@ fn main() -> ! {
             ..Config::default()
         },
         clkcntrl_config,
-        &mut dport,
     )
     .unwrap();
 

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -88,7 +88,7 @@ impl<
 fn main() -> ! {
     let dp = target::Peripherals::take().expect("Failed to obtain Peripherals");
 
-    let (mut dport, dport_clock_control) = dp.DPORT.split();
+    let (_, dport_clock_control) = dp.DPORT.split();
 
     let clkcntrl = ClockControl::new(
         dp.RTCCNTL,
@@ -123,7 +123,6 @@ fn main() -> ! {
             ..serial::config::Config::default()
         },
         clkcntrl_config,
-        &mut dport,
     )
     .unwrap();
 
@@ -145,7 +144,6 @@ fn main() -> ! {
             data_mode: spi::config::MODE_0,
         },
         clkcntrl_config,
-        &mut dport,
     )
     .unwrap();
 

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -41,7 +41,7 @@ static TX: CriticalSectionSpinLockMutex<Option<esp32_hal::serial::Tx<esp32::UART
 fn main() -> ! {
     let dp = target::Peripherals::take().unwrap();
 
-    let (mut dport, dport_clock_control) = dp.DPORT.split();
+    let (_, dport_clock_control) = dp.DPORT.split();
 
     let clkcntrl = esp32_hal::clock_control::ClockControl::new(
         dp.RTCCNTL,
@@ -93,7 +93,6 @@ fn main() -> ! {
         },
         config,
         clkcntrl_config,
-        &mut dport,
     )
     .unwrap();
 

--- a/flash
+++ b/flash
@@ -243,7 +243,7 @@ then
         then
             printf "\n\n"
             # get gen_esp32part.py and create binary partition table
-            curl -s -S -f --max-time 2 -L $GENPART_SOURCE --output target/gen_esp32part.py_new
+            curl -s -S -f --max-time 5 -L $GENPART_SOURCE --output target/gen_esp32part.py_new
 
             if [ $? -ne 0 ]; then
                 if [ -f target/gen_esp32part.py ]; then
@@ -269,7 +269,7 @@ then
 
         # get bootloader.bin file 
         # (different variants exist, but only difference is flash settings which are overriden by esptool)
-        curl -s -S -f --max-time 2 -L $BOOTLOADER_SOURCE --output target/bootloader.bin_new 
+        curl -s -S -f --max-time 5 -L $BOOTLOADER_SOURCE --output target/bootloader.bin_new 
 
         if [ $? -ne 0 ]; then
             if [ -f target/bootloader.bin ]; then

--- a/memory.x
+++ b/memory.x
@@ -161,7 +161,23 @@ SECTIONS {
     _external_heap_start = ABSOLUTE(.);
   } > psram_seg
 
-}
+
+  /* wifi data */
+
+  .rwtext.wifi :
+  {
+    . = ALIGN(4);
+    *( .wifi0iram  .wifi0iram.*)
+    *( .wifirxiram  .wifirxiram.*)
+    *( .iram1  .iram1.*)
+  } > RWTEXT AT > RODATA
+
+  .data.wifi :
+  {
+    . = ALIGN(4);
+    *( .dram1 .dram1.*)
+  } > RWDATA AT > RODATA
+} 
 
 _external_ram_start = ABSOLUTE(ORIGIN(psram_seg));
 _external_ram_end = ABSOLUTE(ORIGIN(psram_seg)+LENGTH(psram_seg));
@@ -176,4 +192,8 @@ _stack_start_cpu0 = _stack_end_cpu1;
 _stack_end_cpu0 = _stack_start_cpu0 + STACK_SIZE;
 
 EXTERN(DefaultHandler);
+
+EXTERN(WIFI_EVENT); /* Force inclusion of WiFi libraries */
+
 INCLUDE "device.x"
+

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -5,6 +5,10 @@
 //! The allocators can be safely used in a mixed fashion. (Including multiple GeneralAllocators
 //! with different thresholds)
 //!
+//! **NOTE: iram can only be accessed by aligned 32-bit accesses, as structures can indicate
+//! alignment >= 4 even when members are smaller, it cannot be used for general rust allocations.
+//! (Unless a load/store exception handler is used, but this will be very slow.)
+//!
 //! **NOTE: the default implementations of memcpy, memset etc. which are used behind the scenes use
 //! unaligned accesses.** This causes exceptions when used together with IRAM.
 //! The replacements in the mem module do handle alignment properly. They can be enable by
@@ -27,7 +31,7 @@ use core::ptr::NonNull;
 use linked_list_allocator::Heap;
 
 const DEFAULT_EXTERNAL_THRESHOLD: usize = 32 * 1024;
-const DEFAULT_USE_IRAM: bool = true;
+const DEFAULT_USE_IRAM: bool = false;
 
 /// Default allocator using a mix of memories.
 ///

--- a/src/clock_control/cpu.rs
+++ b/src/clock_control/cpu.rs
@@ -136,12 +136,13 @@ impl super::ClockControl {
     ///
     /// The second core will start running with the function `entry`.
     pub fn start_app_core(&mut self, entry: fn() -> !) -> Result<(), Error> {
-        if self
-            .dport_control
-            .appcpu_ctrl_b()
-            .read()
-            .appcpu_clkgate_en()
-            .bit_is_set()
+        if !xtensa_lx6::is_debugger_attached()
+            && self
+                .dport_control
+                .appcpu_ctrl_b()
+                .read()
+                .appcpu_clkgate_en()
+                .bit_is_set()
         {
             return Err(Error::CoreAlreadyRunning);
         }

--- a/src/dport.rs
+++ b/src/dport.rs
@@ -4,6 +4,8 @@
 //! Registers needed in other blocks can be split off.
 //!
 use crate::target::{dport, DPORT};
+use xtensa_lx6::mutex::mutex_trait::Mutex;
+use xtensa_lx6::mutex::CriticalSectionSpinLockMutex;
 
 /// Cpu Period Configuration Register
 pub struct ClockControl {}
@@ -50,4 +52,202 @@ impl Split for DPORT {
     fn split(self) -> (DPORT, ClockControl) {
         (self, ClockControl {})
     }
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone)]
+pub enum Peripheral {
+    TIMERS = 0,
+    SPI0_SPI1 = 1,
+    UART0 = 2,
+    WDG = 3,
+    I2S0 = 4,
+    UART1 = 5,
+    SPI2 = 6,
+    I2C0 = 7,
+    UHCI0 = 8,
+    RMT = 9,
+    PCNT = 10,
+    LEDC = 11,
+    UHCI1 = 12,
+    TIMERGROUP0 = 13,
+    EFUSE = 14,
+    TIMERGROUP1 = 15,
+    SPI3 = 16,
+    PWM0 = 17,
+    I2C1 = 18,
+    CAN = 19,
+    PWM1 = 20,
+    I2S1 = 21,
+    SPI_DMA = 22,
+    UART2 = 23,
+    UART_MEM = 24,
+    PWM2 = 25,
+    PWM3 = 26,
+    AES = 32 + 0,
+    SHA = 32 + 1,
+    RSA = 32 + 2,
+    SECUREBOOT = 32 + 3,
+    SIGNATURE = 32 + 4,
+
+    SDIO_SLAVE = 64 + 4,
+    SDIO_HOST = 64 + 13,
+    EMAC = 64 + 14,
+    RNG = 64 + 15,
+
+    WIFI = 96,
+    BT = 97,
+    WIFI_BT_COMMON = 98,
+    BT_LC = 99,
+    BT_BASEBAND = 100,
+}
+
+static PERIPHERAL_MUTEX: CriticalSectionSpinLockMutex<()> = CriticalSectionSpinLockMutex::new(());
+
+const WIFI_CLK_MASK: u32 = 0x406; // bits 1, 2, 10
+const BT_CLK_MASK: u32 = 0x61; // bits 11, 16, 17
+const WIFI_BT_CLK_MASK: u32 = 0x3c9; // bits 0, 3, 6, 7, 8, 9
+const BT_LC_CLK_MASK: u32 = 0x3000; // bit 16, 17
+const BT_BASEBAND_CLK_MASK: u32 = 0x0800; // bit 11
+
+const EMAC_RST_MASK: u32 = 0x80; // bit 7
+const SDIO_HOST_RST_MASK: u32 = 0x40; // bit 6
+const SDIO_SLAVE_RST_MASK: u32 = 0x20; // bit 5
+
+const UART_MASK: u32 = 1 << (Peripheral::UART0 as u32)
+    | 1 << (Peripheral::UART1 as u32)
+    | 1 << (Peripheral::UART2 as u32);
+
+pub fn enable_peripheral(peripheral: Peripheral) {
+    let bitnr = peripheral as u32;
+    let dport = unsafe { &(*DPORT::ptr()) };
+    (&PERIPHERAL_MUTEX).lock(|_| unsafe {
+        if bitnr < 32 {
+            let mut mask = 1 << bitnr;
+            match peripheral {
+                Peripheral::UART0 | Peripheral::UART1 | Peripheral::UART2 => {
+                    mask |= 1 << (Peripheral::UART_MEM as u32)
+                }
+                _ => {}
+            }
+
+            dport.perip_clk_en.modify(|r, w| w.bits(r.bits() | mask));
+            dport.perip_rst_en.modify(|r, w| w.bits(r.bits() & !mask));
+        } else if bitnr < 64 {
+            let mut mask = 1 << (bitnr - 32);
+            match peripheral {
+                Peripheral::AES => {
+                    mask |= 1 << (Peripheral::SIGNATURE as u32 - 32)
+                        | 1 << (Peripheral::SECUREBOOT as u32 - 32);
+                }
+                Peripheral::SHA => {
+                    mask |= 1 << (Peripheral::SECUREBOOT as u32 - 32);
+                }
+                Peripheral::RSA => {
+                    mask |= 1 << (Peripheral::SIGNATURE as u32 - 32);
+                }
+                _ => {}
+            }
+
+            dport.peri_clk_en.modify(|r, w| w.bits(r.bits() | mask));
+            dport.peri_rst_en.modify(|r, w| w.bits(r.bits() & !mask));
+        } else if bitnr < 96 {
+            let mask = 1 << (bitnr - 64);
+            dport.wifi_clk_en.modify(|r, w| w.bits(r.bits() | mask));
+
+            let rst_mask = match peripheral {
+                Peripheral::EMAC => EMAC_RST_MASK,
+                Peripheral::SDIO_HOST => SDIO_HOST_RST_MASK,
+                Peripheral::SDIO_SLAVE => SDIO_SLAVE_RST_MASK,
+                _ => 0,
+            };
+            dport
+                .core_rst_en
+                .modify(|r, w| w.bits(r.bits() & !rst_mask));
+        } else {
+            let mask = match peripheral {
+                Peripheral::WIFI => WIFI_CLK_MASK,
+                Peripheral::BT => BT_CLK_MASK,
+                Peripheral::WIFI_BT_COMMON => WIFI_BT_CLK_MASK,
+                Peripheral::BT_BASEBAND => BT_BASEBAND_CLK_MASK,
+                Peripheral::BT_LC => BT_LC_CLK_MASK,
+                _ => 0,
+            };
+            dport.wifi_clk_en.modify(|r, w| w.bits(r.bits() | mask));
+            // no reset done
+        }
+    });
+}
+
+pub fn disable_peripheral(peripheral: Peripheral) {
+    let bitnr = peripheral as u32;
+    let dport = unsafe { &(*DPORT::ptr()) };
+    (&PERIPHERAL_MUTEX).lock(|_| unsafe {
+        if bitnr < 32 {
+            let mut mask = 1 << bitnr;
+            dport.perip_clk_en.modify(|r, w| {
+                if r.bits() & !mask & UART_MASK == 0 {
+                    mask &= !(1 << (Peripheral::UART_MEM as u32));
+                }
+                w.bits(r.bits() & !mask)
+            });
+            dport.perip_rst_en.modify(|r, w| w.bits(r.bits() | mask));
+        } else if bitnr < 64 {
+            let mask = 1 << (bitnr - 32);
+
+            dport.peri_clk_en.modify(|r, w| w.bits(r.bits() & !mask));
+            dport.peri_rst_en.modify(|r, w| w.bits(r.bits() | mask));
+        } else if bitnr < 96 {
+            let mask = 1 << (bitnr - 64);
+            dport.wifi_clk_en.modify(|r, w| w.bits(r.bits() & !mask));
+
+            let rst_mask = match peripheral {
+                Peripheral::EMAC => EMAC_RST_MASK,
+                Peripheral::SDIO_HOST => SDIO_HOST_RST_MASK,
+                Peripheral::SDIO_SLAVE => SDIO_SLAVE_RST_MASK,
+                _ => 0,
+            };
+            dport.core_rst_en.modify(|r, w| w.bits(r.bits() | rst_mask));
+        } else {
+            let mask = match peripheral {
+                Peripheral::WIFI => WIFI_CLK_MASK,
+                Peripheral::BT => BT_CLK_MASK,
+                Peripheral::WIFI_BT_COMMON => WIFI_BT_CLK_MASK,
+                Peripheral::BT_BASEBAND => BT_BASEBAND_CLK_MASK,
+                Peripheral::BT_LC => BT_LC_CLK_MASK,
+                _ => 0,
+            };
+            dport.wifi_clk_en.modify(|r, w| w.bits(r.bits() & !mask));
+            // no reset done
+        }
+    });
+}
+
+pub fn reset_peripheral(peripheral: Peripheral) {
+    let bitnr = peripheral as u32;
+    let dport = unsafe { &(*DPORT::ptr()) };
+    (&PERIPHERAL_MUTEX).lock(|_| unsafe {
+        if bitnr < 32 {
+            let mask = 1 << bitnr;
+            dport.perip_rst_en.modify(|r, w| w.bits(r.bits() | mask));
+            dport.perip_rst_en.modify(|r, w| w.bits(r.bits() & !mask));
+        } else if bitnr < 64 {
+            let mask = 1 << (bitnr - 32);
+            dport.peri_rst_en.modify(|r, w| w.bits(r.bits() | mask));
+            dport.peri_rst_en.modify(|r, w| w.bits(r.bits() & !mask));
+        } else if bitnr < 96 {
+            let rst_mask = match peripheral {
+                Peripheral::EMAC => EMAC_RST_MASK,
+                Peripheral::SDIO_HOST => SDIO_HOST_RST_MASK,
+                Peripheral::SDIO_SLAVE => SDIO_SLAVE_RST_MASK,
+                _ => 0,
+            };
+            dport.core_rst_en.modify(|r, w| w.bits(r.bits() | rst_mask));
+            dport
+                .core_rst_en
+                .modify(|r, w| w.bits(r.bits() & !rst_mask));
+        } else {
+            // do nothing for WiFi / Bluetooth
+        }
+    });
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,6 +10,7 @@
 pub use xtensa_lx6_rt::{entry, exception};
 
 pub use crate::analog::SensExt;
+pub use crate::dport::{self, Peripheral};
 pub use crate::gpio::GpioExt;
 pub use crate::interrupt;
 pub use crate::proc_macros::*;


### PR DESCRIPTION
- Extended timer module functionality to allow creation of software timers for e.g. wifi
- Centralized peripheral enable/disable code
- Modified examples accordingly