### PR TITLE
Pre 0.1.0 fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ esp32 = { version = "0.7.0", default-features = false }
 bare-metal = "0.2"
 nb = "0.1.2"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
-linked_list_allocator = { version = "0.8.4", optional = true, default-features = false, features = ["alloc_ref"] }
+linked_list_allocator = { version = "=0.8.4", optional = true, default-features = false, features = ["alloc_ref"] }
 void = { version = "1.0.2", default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rt = ["esp32/rt", "xtensa-lx6-rt"]
 [dependencies]
 esp32-hal-proc-macros = { path = "procmacros" }
 
-xtensa-lx6-rt = { version = "0.3.0", optional = true }
+xtensa-lx6-rt = { version = "0.4.0", optional = true }
 xtensa-lx6 = "0.2.0"
 esp32 = { version = "0.7.0", default-features = false }
 bare-metal = "0.2"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,27 @@
 # esp32-hal
 
-A experimental hardware abstraction layer for the [esp32](https://en.wikipedia.org/wiki/ESP32) written in Rust.
+A hardware abstraction layer for the [esp32](https://en.wikipedia.org/wiki/ESP32) written in Rust.
 
 Contributions are welcome :)
 
 Join in on the discussion: https://matrix.to/#/#esp-rs:matrix.org!
+
+## Running examples
+
+There are currently two ways to flash the esp32:
+
+  * The `flash` script using `esptool` 
+    - If you are familiar with the esp ecosystem, there is a `flash` script in this repo which utilizes the espressif esptool to flash the esp32 over usb.
+    Example usage:
+     ```rust
+        ./flash -p /dev/ttyUSB0 -e blinky --release
+     ```
+  
+  * The [`espflash`](https://github.com/icewind1991/espflash) cargo subcommand
+    - A Rust rewrite of the esptool, with a cargo subcommand. Example usage:
+     ```rust
+        cargo espflash --example blinky --release /dev/ttyUSB0
+     ```
 
 ## License
 

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -30,7 +30,7 @@ fn main() -> ! {
     disable_rtc_wdt(&mut rtccntl);
 
     let pins = dp.GPIO.split();
-    let mut led = pins.gpio2.into_open_drain_output();
+    let mut led = pins.gpio2.into_push_pull_output();
 
     loop {
         led.set_high().unwrap();

--- a/memory.x
+++ b/memory.x
@@ -59,12 +59,6 @@ INCLUDE "alias.x"
 
 /* esp32 specific regions */
 SECTIONS {
-  .rwtext :
-  {
-   . = ALIGN(4);
-    *(.rwtext.literal .rwtext .rwtext.literal.* .rwtext.*)
-  } > iram_seg AT > RODATA
-
   .rtc_fast.text : {
    . = ALIGN(4);
     *(.rtc_fast.literal .rtc_fast.text .rtc_fast.literal.* .rtc_fast.text.*)


### PR DESCRIPTION
* Fix examples requiring the `alloc` feature. 
* Lock `linked_list_allocator` to 0.8.4. Breaking changes to the `alloc_ref` feature in 0.8.5.