### PR TITLE
Pin version of linked_list_allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ esp32 = "0.10.0"
 bare-metal = "0.2"
 nb = "0.1.2"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
-linked_list_allocator = { version = "0.8.5", optional = true, default-features = false, features = ["alloc_ref"] }
+linked_list_allocator = { version = "=0.8.6", optional = true, default-features = false, features = ["alloc_ref"] }
 void = { version = "1.0.2", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
The reason is that due to recent changes in Rust and the [reaction of linked_list_allocator](https://github.com/phil-opp/linked-list-allocator/blob/master/Changelog.md) to those changes, we'll get breakages such as https://github.com/esp-rs/esp32-wifi/issues/2.

This should solve itself with an update of the Rust version in rust-xtensa but for now, the best we can do is fix this version.