### PR TITLE
Updates for rust 1.50

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ esp32 = "0.10.0"
 bare-metal = "0.2"
 nb = "0.1.2"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
-linked_list_allocator = { version = "=0.8.6", optional = true, default-features = false, features = ["alloc_ref"] }
+linked_list_allocator = { version = "=0.8.11", optional = true, default-features = false, features = ["alloc_ref"] }
 void = { version = "1.0.2", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
`AllocRef` renamed to `Allocator`, use `linked_list_allocator` 0.8.11, which also has those renames done.