### PR TITLE
v0.3.0 - Ecosystem bump

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -7,3 +7,6 @@ rustflags = [
   "-C", "link-arg=-Wl,-Tlink.x",
 ]
 target = "xtensa-esp32-none-elf"
+
+[unstable]
+build-std=["core", "alloc"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## v0.2.0 - 2020-09-23
+## [v0.3.0] - 2021-08-12
+
+### Additions
+  - Basic I2C Support
+
+### Fixed
+  - Fix compilication errors around the `const_fn` feature.
+  - Bumped `xtensa-lx`, `xtensa-lx-rt` & `esp32` to support newer compilers.
+
+## [v0.2.0] - 2020-09-23
 
 ### Changed
   - Replace `xtenxa-lx6` with `xtensa-lx`, a silicon agnostic craate for the runtime and peripheral access of xtensa CPU's.
@@ -14,10 +23,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Update alloc to support the new `alloc_ref` nightly changes.
   - Clean up examples
 
-## v0.1.0 - 2020-09-15
+## [v0.1.0] - 2020-09-15
 
 - Initial release
 
-[Unreleased]: https://github.com/esp-rs/esp32-hal/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/esp-rs/esp32-hal/compare/v0.3.0...HEAD
+[v0.3.0]: https://github.com/esp-rs/esp32-hal/compare/v0.2.0...v0.3.0
 [v0.2.0]: https://github.com/esp-rs/esp32-hal/compare/v0.1.0...v0.2.0
 [v0.1.0]: https://github.com/esp-rs/esp32-hal/tree/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ rt = ["esp32/rt", "xtensa-lx-rt"]
 [dependencies]
 esp32-hal-proc-macros = { version = "=0.2.0", path = "procmacros" }
 
-xtensa-lx-rt = { version = "0.5.0", optional = true, features = ["lx6"] }
-xtensa-lx = { version = "0.3.0", features = ["lx6"]}
-esp32 = "0.10.0"
+xtensa-lx-rt = { version = "0.7.0", optional = true, features = ["lx6"] }
+xtensa-lx = { version = "0.4.0", features = ["lx6"] }
+esp32 = "0.11.0"
 bare-metal = "0.2"
 nb = "0.1.2"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp32-hal"
-version = "0.2.0"
+version = "0.3.0"
 description = "A Hardware abstraction layer for Espressif's ESP32 WiFi microcontroller."
 authors = ["Scott Mabin <scott@mabez.dev>", "Arjan Mels <arjan@mels.email>"]
 categories = ["embedded", "hardware-support", "no-std"]

--- a/examples/ram.rs
+++ b/examples/ram.rs
@@ -215,7 +215,7 @@ fn ram_tests(uart: &mut dyn core::fmt::Write) {
 fn external_ram(_uart: &mut dyn core::fmt::Write) {}
 
 #[cfg(feature = "external_ram")]
-fn external_ram(uart: &mut core::fmt::Write) {
+fn external_ram(uart: &mut dyn core::fmt::Write) {
     unsafe {
         print_info!(uart, ATTR_RAM_STATIC_EXTERNAL);
         print_info!(uart, ATTR_RAM_STATIC_EXTERNAL_BSS);

--- a/openocd.cfg
+++ b/openocd.cfg
@@ -1,0 +1,6 @@
+
+adapter_khz 4000
+
+source [find interface/jlink.cfg]
+
+source [find board/esp-wroom-32.cfg]

--- a/src/clock_control/mod.rs
+++ b/src/clock_control/mod.rs
@@ -18,7 +18,6 @@
 use crate::prelude::*;
 use crate::target;
 use crate::target::dport::cpu_per_conf::CPUPERIOD_SEL_A;
-use crate::target::generic::Variant::*;
 use crate::target::rtccntl::clk_conf::*;
 use crate::target::rtccntl::cntl::*;
 use crate::target::{APB_CTRL, RTCCNTL, TIMG0};
@@ -1141,9 +1140,9 @@ impl ClockControl {
     /// Get Slow RTC source
     pub fn slow_rtc_source(&self) -> Result<SlowRTCSource, Error> {
         match self.rtc_control.clk_conf.read().ana_clk_rtc_sel().variant() {
-            Val(ANA_CLK_RTC_SEL_A::SLOW_CK) => Ok(SlowRTCSource::RTC150k),
-            Val(ANA_CLK_RTC_SEL_A::CK_XTAL_32K) => Ok(SlowRTCSource::Xtal32k),
-            Val(ANA_CLK_RTC_SEL_A::CK8M_D256_OUT) => Ok(SlowRTCSource::RTC8MD256),
+            Some(ANA_CLK_RTC_SEL_A::SLOW_CK) => Ok(SlowRTCSource::RTC150k),
+            Some(ANA_CLK_RTC_SEL_A::CK_XTAL_32K) => Ok(SlowRTCSource::Xtal32k),
+            Some(ANA_CLK_RTC_SEL_A::CK8M_D256_OUT) => Ok(SlowRTCSource::RTC8MD256),
             _ => Err(Error::UnsupportedFreqConfig),
         }
     }
@@ -1273,9 +1272,9 @@ impl ClockControl {
                 .cpuperiod_sel()
                 .variant()
             {
-                Val(CPUPERIOD_SEL_A::SEL_80) => CPU_FREQ_80M,
-                Val(CPUPERIOD_SEL_A::SEL_160) => CPU_FREQ_160M,
-                Val(CPUPERIOD_SEL_A::SEL_240) => CPU_FREQ_240M,
+                Some(CPUPERIOD_SEL_A::SEL_80) => CPU_FREQ_80M,
+                Some(CPUPERIOD_SEL_A::SEL_160) => CPU_FREQ_160M,
+                Some(CPUPERIOD_SEL_A::SEL_240) => CPU_FREQ_240M,
                 _ => FREQ_OFF,
             },
             CPUSource::RTC8M => self.rtc8m_frequency_measured,

--- a/src/clock_control/pll.rs
+++ b/src/clock_control/pll.rs
@@ -3,7 +3,6 @@
 
 use super::Error;
 use crate::prelude::*;
-use crate::target::generic::Variant::Val;
 
 // Delays (in microseconds) for changing pll settings
 // TODO according to esp-idf: some of these are excessive, and should be reduced.
@@ -197,9 +196,9 @@ impl super::ClockControl {
             .cpuperiod_sel()
             .variant()
         {
-            Val(super::CPUPERIOD_SEL_A::SEL_80) => super::PLL_FREQ_320M,
-            Val(super::CPUPERIOD_SEL_A::SEL_160) => super::PLL_FREQ_320M,
-            Val(super::CPUPERIOD_SEL_A::SEL_240) => super::PLL_FREQ_480M,
+            Some(super::CPUPERIOD_SEL_A::SEL_80) => super::PLL_FREQ_320M,
+            Some(super::CPUPERIOD_SEL_A::SEL_160) => super::PLL_FREQ_320M,
+            Some(super::CPUPERIOD_SEL_A::SEL_240) => super::PLL_FREQ_480M,
             _ => super::FREQ_OFF,
         }
     }

--- a/src/clock_control/watchdog.rs
+++ b/src/clock_control/watchdog.rs
@@ -6,7 +6,6 @@
 
 use crate::prelude::*;
 use crate::target;
-use crate::target::generic::Variant::Val;
 use crate::target::rtccntl::wdtconfig0::*;
 use crate::target::RTCCNTL;
 use embedded_hal::watchdog::{WatchdogDisable, WatchdogEnable};
@@ -105,19 +104,19 @@ impl Watchdog {
         let wdtconfig0 = rtc_control.wdtconfig0.read();
 
         let stg0 = match wdtconfig0.wdt_stg0().variant() {
-            Val(x) => x,
+            Some(x) => x,
             _ => return Err(super::Error::UnsupportedWatchdogConfig),
         };
         let stg1 = match wdtconfig0.wdt_stg1().variant() {
-            Val(x) => x,
+            Some(x) => x,
             _ => return Err(super::Error::UnsupportedWatchdogConfig),
         };
         let stg2 = match wdtconfig0.wdt_stg2().variant() {
-            Val(x) => x,
+            Some(x) => x,
             _ => return Err(super::Error::UnsupportedWatchdogConfig),
         };
         let stg3 = match wdtconfig0.wdt_stg3().variant() {
-            Val(x) => x,
+            Some(x) => x,
             _ => return Err(super::Error::UnsupportedWatchdogConfig),
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
 #![cfg_attr(feature = "alloc", feature(alloc_layout_extra))]
 #![cfg_attr(feature = "alloc", feature(nonnull_slice_from_raw_parts))]
+#![cfg_attr(feature = "alloc", feature(const_fn_trait_bound))]
 
 pub use embedded_hal as hal;
 pub use esp32 as target;
@@ -88,6 +89,14 @@ pub unsafe extern "C" fn ESP32Reset() -> ! {
 
     // continue with default reset handler
     xtensa_lx_rt::Reset();
+}
+
+/// The esp32 has a first stage bootloader that handles loading program data into the right place
+/// therefore we skip loading it again.
+#[no_mangle]
+#[rustfmt::skip]
+pub extern "Rust" fn __init_data() -> bool {
+    false
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]


### PR DESCRIPTION
* Bump xtensa-lx crates
* Bump esp32 crate
* Update to fix any breaking changes
* use `build-std` by default - now that
https://github.com/rust-lang/compiler-builtins/pull/411 is merged

NOTE: requires esp32 0.11 release before merge: https://github.com/esp-rs/esp32/pull/45